### PR TITLE
Better forward compatibility

### DIFF
--- a/dev/build_update.py
+++ b/dev/build_update.py
@@ -141,9 +141,8 @@ def build_update_file(
     meta_data = {
         "update_file_format": "1.0",
         "supported_hardware": ["vector_v4", "vector_v5"],
-        "supported_software_versions": ["0.3.0"],
         "micropython_versions": ["1.24.1"],
-        "downgradable_to": ["0.3.0"],
+        "downgradable_to": ["1.0.0"],
         "version": version,
     }
     metadata_line = json.dumps(meta_data, separators=(",", ":"))

--- a/src/SharedState.py
+++ b/src/SharedState.py
@@ -1,7 +1,7 @@
 from micropython import const
 
 # TODO use const else where
-WarpedVersion = const("0.4.4")
+WarpedVersion = const("1.0.0")
 WarpedCodeBase = const("SYSTEM11")
 
 # true false - tournament mode

--- a/src/update.py
+++ b/src/update.py
@@ -271,13 +271,6 @@ def validate_compatibility():
     if incoming_update_file_format not in supported_update_file_formats:
         raise Exception(f"Update file format ({incoming_update_file_format}) not in supported formats: {supported_update_file_formats}")
 
-    from SharedState import WarpedVersion
-
-    current_version_obj = Version.from_str(WarpedVersion)
-    supported_versions = [Version.from_str(v) for v in metadata.get("supported_software_versions", [])]
-    if not any(current_version_obj == sv for sv in supported_versions):
-        raise Exception(f"Version {current_version_obj} not in supported versions: {[str(v) for v in supported_versions]}")
-
     from sys import implementation
 
     mp_version_obj = Version(


### PR DESCRIPTION
I think we can ditch the supported warped pinball versions from the update files.

**How do we handle new users who want to update many versions after we inevitably change the format of the update file?**

We will produce a small update.json with every update after that point, that adds the functionality required to handle the new update format, which we would still attach to the same release, with a different name perhaps update_v2.json or similar. 

