### PR TITLE
Added manual port

### DIFF
--- a/dev/sync.sh
+++ b/dev/sync.sh
@@ -29,8 +29,11 @@ fi
 echo "Flashing the Pico ..."
 # We'll pass the same environment if needed, but flash.py might not need it
 # for the basic steps. Adjust if your flash.py script has extra flags.
-echo "$PORT"
-python dev/flash.py "$BUILD_DIR" --port "$PORT"
+PORT_PARAM=""
+if [ -n "$PORT" ]; then
+PORT_PARAM="--port ${PORT}"
+fi
+python dev/flash.py "$BUILD_DIR" $PORT_PARAM
 if [ $? -ne 0 ]; then
   echo "Flashing failed. Aborting."
   exit 1

--- a/dev/sync.sh
+++ b/dev/sync.sh
@@ -15,6 +15,7 @@
 ENVIRONMENT="${1:-dev}"     # If user doesn't specify, default to 'dev'
 BUILD_DIR="build"           # adjust as necessary
 SOURCE_DIR="src"            # adjust as necessary
+PORT="${2}"                # optionally define port
 
 # --- 1. Build the project ---
 echo "Building project with environment=${ENVIRONMENT} ..."
@@ -28,7 +29,8 @@ fi
 echo "Flashing the Pico ..."
 # We'll pass the same environment if needed, but flash.py might not need it
 # for the basic steps. Adjust if your flash.py script has extra flags.
-python dev/flash.py "$BUILD_DIR"
+echo "$PORT"
+python dev/flash.py "$BUILD_DIR" --port "$PORT"
 if [ $? -ne 0 ]; then
   echo "Flashing failed. Aborting."
   exit 1


### PR DESCRIPTION
## Description
Added manual port override when running sync.sh script
`dev/sync.sh dev <your pi port here>`

## Related Issues
https://github.com/warped-pinball/vector/issues/69

## Motivation and Context
Allows me to use the sync.sh script on my mac, which isn't correctly selecting the default port via mpremote

## Testing
Tested locally on my mac, I don't see any unit tests to update just yet 👀 

## Types of Changes
- [X] Bug fix (non-breaking change to resolve an issue)
- [X] New feature (non-breaking change to add functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] Documentation update required

## Checklist
- [?] My code follows the project’s style guidelines.
- [ ] I have updated documentation as needed.
- [X] I have read the CONTRIBUTING.md document.
- [ ] I have added or updated tests.
- [ ] All new and existing tests pass.

