### PR TITLE
Sys9 score fix

### DIFF
--- a/src/ScoreTrack.py
+++ b/src/ScoreTrack.py
@@ -177,7 +177,7 @@ def place_machine_scores():
     for index in range(4):
         if len(top_scores[index]["initials"]) != 3:
             top_scores[index]["initials"] = "   "
-            top_scores[index]["score"] = 100
+            #top_scores[index]["score"] = 100  only change intials, not score (blank initials happen with good scores sometimes)
 
     if S.gdata["HighScores"]["Type"] == 1 or S.gdata["HighScores"]["Type"] == 3:
         log.log("SCORE: Place system 11 machine scores")
@@ -214,6 +214,7 @@ def place_machine_scores():
         for index in range(4):
             score_start = S.gdata["HighScores"]["ScoreAdr"] + index * S.gdata["HighScores"]["BytesInScore"]
             shadowRam[score_start : score_start + 4] = _int_to_bcd(top_scores[index]["score"])
+            print("  top scores: ", top_scores[index])
 
 
 def _remove_machine_scores():

--- a/src/ScoreTrack.py
+++ b/src/ScoreTrack.py
@@ -177,7 +177,7 @@ def place_machine_scores():
     for index in range(4):
         if len(top_scores[index]["initials"]) != 3:
             top_scores[index]["initials"] = "   "
-            #top_scores[index]["score"] = 100  only change intials, not score (blank initials happen with good scores sometimes)
+            #top_scores[index]["score"] = 100  only change initials, not score (blank initials happen with good scores sometimes)
 
     if S.gdata["HighScores"]["Type"] == 1 or S.gdata["HighScores"]["Type"] == 3:
         log.log("SCORE: Place system 11 machine scores")

--- a/src/ScoreTrack.py
+++ b/src/ScoreTrack.py
@@ -214,7 +214,6 @@ def place_machine_scores():
         for index in range(4):
             score_start = S.gdata["HighScores"]["ScoreAdr"] + index * S.gdata["HighScores"]["BytesInScore"]
             shadowRam[score_start : score_start + 4] = _int_to_bcd(top_scores[index]["score"])
-            print("  top scores: ", top_scores[index])
 
 
 def _remove_machine_scores():

--- a/src/SharedState.py
+++ b/src/SharedState.py
@@ -1,4 +1,4 @@
-WarpedVersion = "1.3.7"
+WarpedVersion = "1.3.8"
 
 # counts game start cycles
 gameCounter = 0


### PR DESCRIPTION
## Description
System 9 and 11 issue with power up score initial when initials are blank.
previously would set score to 100 in error

## Related Issues
system 11 not initializing high scores on power up

## Motivation and Context
<!--- Explain why this change is required and what problem it solves -->

## Testing
<!--- Describe your testing steps, environments, and any relevant details -->

## Screenshots (if applicable)
<!--- Add screenshots if appropriate -->

## Types of Changes
- [ ] Bug fix (non-breaking change to resolve an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] Documentation update required

## Checklist
- [ ] My code follows the project’s style guidelines.
- [ ] I have updated documentation as needed.
- [ ] I have read the CONTRIBUTING.md document.
- [ ] I have added or updated tests.
- [ ] All new and existing tests pass.

## Additional Notes
<!--- Add any extra information here -->
