### PR TITLE
don't loop forever when there's no wifi

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -9,7 +9,6 @@ import uctypes
 from ls import ls
 from machine import RTC
 from Shadow_Ram_Definitions import SRAM_DATA_BASE, SRAM_DATA_LENGTH
-from uctypes import bytearray_at
 from ujson import dumps as json_dumps
 
 import faults
@@ -488,11 +487,11 @@ def app_updatePlayer(request):
     index = int(body["id"])
     if index < 0 or index > ds_memory_map["names"]["count"]:
         raise ValueError(f"Invalid index: {index}")
-  
-    initials = body["initials"].upper()  #very particular intials conditioning
+
+    initials = body["initials"].upper()  # very particular intials conditioning
     i_intials = ""
     for c in initials:
-        if 'A' <= c <= 'Z':
+        if "A" <= c <= "Z":
             i_intials += c
     initials = (i_intials + "   ")[:3]
 
@@ -652,17 +651,17 @@ def app_factoryReset(request):
     Log = logger_instance
 
     reset_control.reset()  # turn off pinbal machine
-    ram_access = uctypes.bytearray_at(SRAM_DATA_BASE, SRAM_DATA_LENGTH)   
-    Log.delete_log()   
+    ram_access = uctypes.bytearray_at(SRAM_DATA_BASE, SRAM_DATA_LENGTH)
+    Log.delete_log()
     D_blank()
-    A_blank()    
+    A_blank()
     Log.log("BKD: Factory Reset")
 
-    #corrupt adjustments to force game factory reset on next boot
-    for i in range(1930, 1970):  
+    # corrupt adjustments to force game factory reset on next boot
+    for i in range(1930, 1970):
         ram_access[i] = 0
-    write_16_fram(SRAM_DATA_BASE + 1930, 1930)        
-    write_16_fram(SRAM_DATA_BASE + 1950, 1950)  
+    write_16_fram(SRAM_DATA_BASE + 1930, 1930)
+    write_16_fram(SRAM_DATA_BASE + 1950, 1950)
 
     reset()  # reset PICO
 
@@ -858,7 +857,7 @@ def add_ap_mode_routes():
 def connect_to_wifi(initialize=False):
     from phew import is_connected_to_wifi as phew_is_connected
 
-    if phew_is_connected() and initialize==False:
+    if phew_is_connected() and not initialize:
         return True
 
     from discovery import setup as discovery_setup
@@ -932,9 +931,6 @@ def go(ap_mode):
         dns.run_catchall(ip)
     else:
         connect_to_wifi(True)
-        while not connect_to_wifi():
-            print("retrying wifi")
-            sleep(1)
         Pico_Led.on()
         add_app_mode_routes()
         from phew.server import set_callback


### PR DESCRIPTION
## Description
Resolves no-wifi situations from preventing vector from booting fully

## Motivation and Context
In cases where there's no wifi on-boot (or ever) the game works fine, but the main server never boots and therefore does not track high scores.

## Types of Changes
- [x] Bug fix (non-breaking change to resolve an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] Documentation update required

## Checklist
- [x] My code follows the project’s style guidelines.
- [x] I have updated documentation as needed.
- [x] I have read the CONTRIBUTING.md document.
- [x] I have added or updated tests.
- [x] All new and existing tests pass.
