### PR TITLE
Update update logic to use new server

### DIFF
--- a/src/common/backend.py
+++ b/src/common/backend.py
@@ -772,13 +772,22 @@ def app_getLogs(request):
 @add_route("/api/update/check", cool_down_seconds=10)
 def app_updates_available(request):
     from mrequests.mrequests import get
+    from SharedState import gdata
 
-    # from urequests import get as urequests_get
+    # determine which update channel to use based on the game config
+    system = "sys11"
+    try:
+        sys_info = gdata.get("GameInfo", {}).get("System", "").upper()
+        if "WPC" in sys_info:
+            system = "wpc"
+        elif "EM" in sys_info:
+            system = "em"
+    except Exception:
+        pass
 
-    url = "https://api.github.com/repos/warped-pinball/vector/releases/latest"
+    url = f"https://updates.warpedpinball.com/{system}/latest.json"
     headers = {
         "User-Agent": "MicroPython-Device",
-        "Accept": "application/vnd.github+json",
     }
 
     resp = get(url, headers=headers)

--- a/src/common/web/js/admin.js
+++ b/src/common/web/js/admin.js
@@ -425,24 +425,20 @@ async function checkForUpdates() {
     const releaseNotes = document.getElementById("release-notes");
     try {
       // check that the release notes are available
-      if (!data["html_url"] || !data["tag_name"]) {
+      if (!data["release_page"] || !data["version"]) {
         throw new Error("No release notes available");
       }
-      releaseNotes.href = data["html_url"];
-      releaseNotes.textContent = "Release Notes for " + data["tag_name"];
+      releaseNotes.href = data["release_page"];
+      releaseNotes.textContent = "Release Notes for " + data["version"];
     } catch (e) {
       releaseNotes.classList.add("hide");
     }
 
     // if the latest is equal to the current version we are up to date
-    if (data["tag_name"] === current) {
+    if (data["version"] === current) {
       updateButton.style.backgroundColor = "#8e8e8e";
       updateButton.style.borderColor = "#8e8e8e";
       updateButton.textContent = "Already up to date";
-      updateButton.disabled = true;
-    } else if (!data["assets"].find((asset) => asset.name === "update.json")) {
-      console.error("No update.json asset found for latest version");
-      updateButton.textContent = "Could not get updates";
       updateButton.disabled = true;
     } else {
       // there is an update with an update.json asset
@@ -451,12 +447,10 @@ async function checkForUpdates() {
       updateButton.disabled = false;
       updateButton.style.backgroundColor = "#e8b85a";
       updateButton.style.borderColor = "#e8b85a";
-      updateButton.textContent = `Update to ${data["tag_name"]}`;
+      updateButton.textContent = `Update to ${data["version"]}`;
 
       // get the url for the update.json asset and add an event listener to the button
-      update_url = data["assets"].find(
-        (asset) => asset.name === "update.json",
-      ).browser_download_url;
+      update_url = data["url"];
 
       // define the call back function to apply the update
       const callback = async () => {
@@ -464,7 +458,7 @@ async function checkForUpdates() {
       };
 
       updateButton.addEventListener("click", async () => {
-        await confirmAction("update to version: " + data["tag_name"], callback);
+        await confirmAction("update to version: " + data["version"], callback);
       });
     }
   } catch (e) {


### PR DESCRIPTION
## Summary
- fetch update metadata from updates.warpedpinball.com instead of GitHub
- pick update channel based on loaded game config
- adjust admin web UI to parse the new JSON format

## Testing
- `pre-commit run --files src/common/backend.py src/common/web/js/admin.js` *(fails: failed to find interpreter for python3.10)*

------
https://chatgpt.com/codex/tasks/task_e_68580ad0e9788330901913c8865e014d