### PR TITLE
Improve memory usage

### DIFF
--- a/src/common/FileIO.py
+++ b/src/common/FileIO.py
@@ -17,14 +17,14 @@ def download_scores():
     data.append(
         {
             "FileType": "leaders",
-            "contents": [DataStore.read_record("leaders", i) for i in range(DataStore.memory_map["leaders"].count)],
+            "contents": [DataStore.read_record("leaders", i) for i in range(DataStore.memory_map["leaders"]["count"])],
         }
     )
 
     data.append(
         {
             "FileType": "tournament",
-            "contents": [DataStore.read_record("tournament", i) for i in range(DataStore.memory_map["tournament"].count)],
+            "contents": [DataStore.read_record("tournament", i) for i in range(DataStore.memory_map["tournament"]["count"])],
         }
     )
 
@@ -37,7 +37,7 @@ def download_names(request):
     print("download names - - - ")
     try:
         # Collect player names data
-        names_data = [DataStore.read_record("names", i) for i in range(DataStore.memory_map["names"].count)]
+        names_data = [DataStore.read_record("names", i) for i in range(DataStore.memory_map["names"]["count"])]
 
         response_body = [{"FileType": "names", "contents": names_data}]
         # Prepare the final response

--- a/src/common/FileIO.py
+++ b/src/common/FileIO.py
@@ -17,14 +17,14 @@ def download_scores():
     data.append(
         {
             "FileType": "leaders",
-            "contents": [DataStore.read_record("leaders", i) for i in range(DataStore.memory_map["leaders"]["count"])],
+            "contents": [DataStore.read_record("leaders", i) for i in range(DataStore.memory_map["leaders"].count)],
         }
     )
 
     data.append(
         {
             "FileType": "tournament",
-            "contents": [DataStore.read_record("tournament", i) for i in range(DataStore.memory_map["tournament"]["count"])],
+            "contents": [DataStore.read_record("tournament", i) for i in range(DataStore.memory_map["tournament"].count)],
         }
     )
 
@@ -37,7 +37,7 @@ def download_names(request):
     print("download names - - - ")
     try:
         # Collect player names data
-        names_data = [DataStore.read_record("names", i) for i in range(DataStore.memory_map["names"]["count"])]
+        names_data = [DataStore.read_record("names", i) for i in range(DataStore.memory_map["names"].count)]
 
         response_body = [{"FileType": "names", "contents": names_data}]
         # Prepare the final response

--- a/src/common/GameDefsLoad.py
+++ b/src/common/GameDefsLoad.py
@@ -14,6 +14,7 @@ import faults
 import SharedState
 import SPI_DataStore
 from logger import logger_instance
+from systemConfig import safe_defaults
 
 Log = logger_instance
 
@@ -41,23 +42,6 @@ def freeze_lists(data):
     if isinstance(data, list):
         return tuple(freeze_lists(v) for v in data)
     return data
-
-
-safe_defaults = {
-    "GameInfo": {"GameName": "Generic System", "System": "X"},
-    "Definition": {"version": 1},
-    "Memory": {"Start": 0, "Length": 2048, "NvStart": 0, "NvLength": 2048},
-    "BallInPlay": {"Type": 0},
-    "InPlay": {"Type": 0},
-    "DisplayMessage": {"Type": 0},
-    "Adjustments": {"Type": 0},
-    "HighScores": {"Type": 0},
-    "HSRewards": {"Type": 0},
-    "Switches": {"Type": 0},
-    "CoinDrop": {"Type": 0},
-}
-
-safe_defaults_wpc = {"Memory": {"Start": 1, "Length": 8192, "NvStart": 2048, "NvLength": 2048}}
 
 
 def parse_config_line(line):
@@ -115,13 +99,6 @@ def go(safe_mode=False):
     Log.log(f"Loading game definitions with safe mode set to {safe_mode}")
 
     data = safe_defaults.copy()
-    try:
-        from systemConfig import vectorSystem
-
-        if vectorSystem == "wpc":
-            data["Memory"] = safe_defaults_wpc["Memory"].copy()
-    except Exception as e:
-        Log.log(f"DEFLOAD: Error importing vectorSystem: {e}")
 
     if not safe_mode:
         try:

--- a/src/common/SPI_DataStore.py
+++ b/src/common/SPI_DataStore.py
@@ -13,56 +13,73 @@ Log = logger_instance
 numberOfPlayers = const(30)
 top_mem = const(32767)
 
-
-class MapEntry:
-    __slots__ = ("start", "size", "count", "sets")
-
-    def __init__(self, start, size, count, sets=None):
-        self.start = start
-        self.size = size
-        self.count = count
-        self.sets = sets
-
-    def __getitem__(self, key):
-        return getattr(self, key)
-
-
-memory_map = {}
-
-_ptr = top_mem
-_ptr -= 16
-memory_map["MapVersion"] = MapEntry(_ptr, 16, 1)
-
-_ptr -= 20 * numberOfPlayers
-memory_map["names"] = MapEntry(_ptr, 20, numberOfPlayers)
-
-_ptr -= 35 * 20
-memory_map["leaders"] = MapEntry(_ptr, 35, 20)
-
-_ptr -= 12 * 100
-memory_map["tournament"] = MapEntry(_ptr, 12, 100)
-
-_ptr -= 14 * 20 * numberOfPlayers
-memory_map["individual"] = MapEntry(_ptr, 14, 20, numberOfPlayers)
-
-_ptr -= 96 * 1
-memory_map["configuration"] = MapEntry(_ptr, 96, 1)
-
-_ptr -= 48 * 1
-memory_map["extras"] = MapEntry(_ptr, 48, 1)
+memory_map = {
+    "MapVersion": {"start": top_mem - 16, "size": 16, "count": 1},
+    "names": {"start": top_mem - 16 - (20 * 30), "size": 20, "count": numberOfPlayers},
+    "leaders": {"start": top_mem - 16 - (20 * 30) - (35 * 20), "size": 35, "count": 20},
+    "tournament": {
+        "start": top_mem - 16 - (20 * 30) - (35 * 20) - (12 * 100),
+        "size": 12,
+        "count": 100,
+    },
+    "individual": {
+        "start": top_mem - 16 - (20 * 30) - (35 * 20) - (12 * 100) - (14 * 20 * 30),
+        "size": 14,
+        "count": 20,
+        "sets": numberOfPlayers,
+    },  # count(scores) of 20, and 30 players
+    "configuration": {
+        "start": top_mem - 16 - (20 * 30) - (35 * 20) - (12 * 100) - (14 * 20 * 30) - (96 * 1),
+        "size": 96,
+        "count": 1,
+    },
+    "extras": {
+        "start": top_mem - 16 - (20 * 30) - (35 * 20) - (12 * 100) - (14 * 20 * 30) - (96 * 1) - (48 * 1),
+        "size": 48,
+        "count": 1,
+    },
+}
 
 
 def show_mem_map():
-    """Print calculated start and end addresses for FRAM structures."""
+    # Calculate the actual start addresses
+    memory_map["MapVersion"]["start"] = top_mem - memory_map["MapVersion"]["size"]
+    memory_map["names"]["start"] = memory_map["MapVersion"]["start"] - (
+        memory_map["names"]["size"] * memory_map["names"]["count"]
+    )
+    memory_map["leaders"]["start"] = memory_map["names"]["start"] - (
+        memory_map["leaders"]["size"] * memory_map["leaders"]["count"]
+    )
+    memory_map["tournament"]["start"] = memory_map["leaders"]["start"] - (
+        memory_map["tournament"]["size"] * memory_map["tournament"]["count"]
+    )
+    memory_map["individual"]["start"] = memory_map["tournament"]["start"] - (
+        memory_map["individual"]["size"]
+        * memory_map["individual"]["count"]
+        * memory_map["individual"]["sets"]
+    )
+    memory_map["configuration"]["start"] = memory_map["individual"]["start"] - (
+        memory_map["configuration"]["size"] * memory_map["configuration"]["count"]
+    )
+    memory_map["extras"]["start"] = memory_map["configuration"]["start"] - (
+        memory_map["extras"]["size"] * memory_map["extras"]["count"]
+    )
+
+    # Calculate the end addresses
     for key, value in memory_map.items():
-        end = value.start + (value.size * value.count) - 1
-        print(f"{key}: start={value.start}, end={end}, size={value.size}, count={value.count}")
+        value["end"] = value["start"] + (value["size"] * value["count"]) - 1
+
+    # Print the final memory map
+    for key, value in memory_map.items():
+        print(
+            f"{key}: start={value['start']}, end={value['end']}, size={value['size']}, count={value['count']}"
+        )
 
 
 def write_record(structure_name, record, index=0, set=0):
     try:
         structure = memory_map[structure_name]
-        start_address = structure.start + index * structure.size + structure.size * structure.count * set
+        start_address = structure["start"] + index * structure["size"] + structure["size"] * structure.get("count", 1) * set
         data = serialize(record, structure_name)
         fram.write(start_address, data)
 
@@ -127,11 +144,11 @@ def serialize(record, structure_name):
 
 def read_record(structure_name, index=0, set=0):
     structure = memory_map[structure_name]
-    if structure.sets is not None:
-        start_address = structure.start + index * structure.size + set * structure.size * structure.count
+    if "sets" in structure:
+        start_address = structure["start"] + index * structure["size"] + set * structure["size"] * structure["count"]
     else:
-        start_address = structure.start + index * structure.size
-    data = fram.read(start_address, structure.size)
+        start_address = structure["start"] + index * structure["size"]
+    data = fram.read(start_address, structure["size"])
     return deserialize(data, structure_name)
 
 
@@ -237,12 +254,12 @@ def blankStruct(structure_name):
         "other": 1,
     }
     structure = memory_map[structure_name]
-    if structure.sets is not None:
-        for x in range(structure.sets):
-            for i in range(structure.count):
+    if "sets" in structure:
+        for x in range(structure["sets"]):
+            for i in range(structure["count"]):
                 write_record(structure_name, fake_entry, i, x)
     else:
-        for i in range(structure.count):
+        for i in range(structure["count"]):
             write_record(structure_name, fake_entry, i)
     Log.log(f"DATST: blank {structure_name}")
 
@@ -250,7 +267,7 @@ def blankStruct(structure_name):
 def blankIndPlayerScores(playernum):
     fake_entry = {"score": 0, "date": ""}
     structure = memory_map["individual"]
-    for i in range(structure.count):
+    for i in range(structure["count"]):
         write_record("individual", fake_entry, i, playernum)
 
 

--- a/src/common/backend.py
+++ b/src/common/backend.py
@@ -398,7 +398,7 @@ def app_game_status(request):
 def get_scoreboard(key, sort_by="score", reverse=False):
     """Get the leaderboard from memory"""
     rows = []
-    for i in range(ds_memory_map[key].count):
+    for i in range(ds_memory_map[key]["count"]):
         row = ds_read_record(key, i)
         if row.get("score", 0) > 0:
             rows.append(row)
@@ -468,7 +468,7 @@ def app_claimScore(request):
 @add_route("/api/players")
 def app_getPlayers(request):
     players = {}
-    count = ds_memory_map["names"].count
+    count = ds_memory_map["names"]["count"]
     # Iterate through the player records
     for i in range(count):
         record = ds_read_record("names", i)
@@ -484,7 +484,7 @@ def app_updatePlayer(request):
     body = request.data
 
     index = int(body["id"])
-    if index < 0 or index > ds_memory_map["names"].count:
+    if index < 0 or index > ds_memory_map["names"]["count"]:
         raise ValueError(f"Invalid index: {index}")
 
     initials = body["initials"].upper()  # very particular intials conditioning
@@ -522,7 +522,7 @@ def app_getScores(request):
     player_record = ds_read_record("names", player_id)
 
     scores = []
-    numberOfScores = ds_memory_map["individual"].count
+    numberOfScores = ds_memory_map["individual"]["count"]
     for i in range(numberOfScores):
         record = ds_read_record("individual", i, player_id)
         score = record["score"]

--- a/src/em/systemConfig.py
+++ b/src/em/systemConfig.py
@@ -3,3 +3,17 @@ updatesURL = "http://software.warpedpinball.com/vector/em/latest.json"
 
 # Firmware version for the EM build
 SystemVersion = "0.0.1"
+
+safe_defaults = {
+    "GameInfo": {"GameName": "Generic System", "System": "X"},
+    "Definition": {"version": 1},
+    "Memory": {"Start": 0, "Length": 2048, "NvStart": 0, "NvLength": 2048},
+    "BallInPlay": {"Type": 0},
+    "InPlay": {"Type": 0},
+    "DisplayMessage": {"Type": 0},
+    "Adjustments": {"Type": 0},
+    "HighScores": {"Type": 0},
+    "HSRewards": {"Type": 0},
+    "Switches": {"Type": 0},
+    "CoinDrop": {"Type": 0},
+}

--- a/src/sys11/systemConfig.py
+++ b/src/sys11/systemConfig.py
@@ -3,3 +3,17 @@ updatesURL = "http://software.warpedpinball.com/vector/sys11/latest.json"
 
 # Firmware version for the System11 build
 SystemVersion = "1.4.0"
+
+safe_defaults = {
+    "GameInfo": {"GameName": "Generic System", "System": "X"},
+    "Definition": {"version": 1},
+    "Memory": {"Start": 0, "Length": 2048, "NvStart": 0, "NvLength": 2048},
+    "BallInPlay": {"Type": 0},
+    "InPlay": {"Type": 0},
+    "DisplayMessage": {"Type": 0},
+    "Adjustments": {"Type": 0},
+    "HighScores": {"Type": 0},
+    "HSRewards": {"Type": 0},
+    "Switches": {"Type": 0},
+    "CoinDrop": {"Type": 0},
+}

--- a/src/wpc/systemConfig.py
+++ b/src/wpc/systemConfig.py
@@ -3,3 +3,17 @@ updatesURL = "http://software.warpedpinball.com/vector/wpc/latest.json"
 
 # Firmware version for the WPC build
 SystemVersion = "0.0.1"
+
+safe_defaults = {
+    "GameInfo": {"GameName": "Generic System", "System": "X"},
+    "Definition": {"version": 1},
+    "Memory": {"Start": 1, "Length": 8192, "NvStart": 2048, "NvLength": 2048},
+    "BallInPlay": {"Type": 0},
+    "InPlay": {"Type": 0},
+    "DisplayMessage": {"Type": 0},
+    "Adjustments": {"Type": 0},
+    "HighScores": {"Type": 0},
+    "HSRewards": {"Type": 0},
+    "Switches": {"Type": 0},
+    "CoinDrop": {"Type": 0},
+}


### PR DESCRIPTION
## Summary
- reuse a shared buffer when streaming files
- avoid reallocating download buffers in updates
- refactor recent score tracking to use a ring buffer
- replace memory map dictionaries with a lightweight class
- freeze config lists into tuples for lower RAM use

## Testing
- `pre-commit run --files src/common/backend.py src/common/update.py src/common/ScoreTrack.py src/common/SPI_DataStore.py src/common/FileIO.py src/common/GameDefsLoad.py`

------
https://chatgpt.com/codex/tasks/task_e_686d62f5c7808330a195ab9709d250a4