### PR TITLE
Fix browser cache after updates

### DIFF
--- a/src/common/web/index.html
+++ b/src/common/web/index.html
@@ -250,7 +250,11 @@
           const { version } = await res.json();
           const current = localStorage.getItem(VERSION_KEY);
           if (current && current !== version) {
+            const savedPassword = localStorage.getItem("password");
             localStorage.clear();
+            if (savedPassword !== null) {
+              localStorage.setItem("password", savedPassword);
+            }
             localStorage.setItem(VERSION_KEY, version);
             location.reload();
           } else if (!current) {


### PR DESCRIPTION
## Summary
- check firmware version on load and clear cached resources if changed
- rely on existing ETag-based caching for HTML

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'uctypes')*

------
https://chatgpt.com/codex/tasks/task_e_687ef021878083308da566a3210e29ee