### PR TITLE
feat: add origin server linking

### DIFF
--- a/src/common/web/html/admin.html
+++ b/src/common/web/html/admin.html
@@ -244,6 +244,9 @@
     <div class="grid">
       <div>
         <button id="link-origin-button">Enable Origin</button>
+        <div id="origin-link" class="hide">
+          <a id="origin-claim-link" target="_blank" rel="noopener noreferrer"></a>
+        </div>
       </div>
       <div>
         <p>

--- a/src/common/web/js/admin.js
+++ b/src/common/web/js/admin.js
@@ -571,7 +571,54 @@ window.customUpdate = async function () {
 // Origin
 //
 
-// check if we've been linked to origin already
-async function checkOriginLinked() {}
+async function checkOriginLinked() {
+  try {
+    const response = await window.smartFetch(
+      "/api/origin/status",
+      null,
+      false,
+    );
+    const data = await response.json();
+    if (data.linked) {
+      const button = document.getElementById("link-origin-button");
+      button.disabled = true;
+      button.textContent = "Origin Enabled";
+    }
+  } catch (e) {
+    console.error("Failed to get origin status", e);
+  }
+}
 
-async function enableOrigin() {}
+async function enableOrigin() {
+  const button = document.getElementById("link-origin-button");
+  button.disabled = true;
+  button.textContent = "Linking...";
+  try {
+    const response = await window.smartFetch(
+      "/api/origin/enable",
+      null,
+      true,
+    );
+    if (!response.ok) {
+      throw new Error("status " + response.status);
+    }
+    const data = await response.json();
+    const linkDiv = document.getElementById("origin-link");
+    const link = document.getElementById("origin-claim-link");
+    link.href = data.claim_url;
+    link.textContent = "Claim This Machine";
+    linkDiv.classList.remove("hide");
+    button.textContent = "Waiting for Claim";
+  } catch (e) {
+    console.error("Failed to enable origin", e);
+    alert("Failed to enable Origin");
+    button.textContent = "Enable Origin";
+    button.disabled = false;
+  }
+}
+
+document
+  .getElementById("link-origin-button")
+  .addEventListener("click", enableOrigin);
+
+checkOriginLinked();

--- a/src/common/websocket_client.py
+++ b/src/common/websocket_client.py
@@ -1,0 +1,97 @@
+import usocket
+import ubinascii
+import urandom
+import struct
+
+class WebSocket:
+    """Minimal synchronous WebSocket client."""
+
+    def __init__(self, sock):
+        self.sock = sock
+
+    def send(self, data):
+        if isinstance(data, str):
+            data = data.encode()
+        length = len(data)
+        # text frame opcode 1, FIN=1
+        header = bytearray([0x81])
+        if length < 126:
+            header.append(0x80 | length)
+        elif length < (1 << 16):
+            header.append(0x80 | 126)
+            header.extend(struct.pack('>H', length))
+        else:
+            header.append(0x80 | 127)
+            header.extend(struct.pack('>Q', length))
+        mask = urandom.getrandbits(32).to_bytes(4, 'big')
+        header.extend(mask)
+        masked = bytes(b ^ mask[i % 4] for i, b in enumerate(data))
+        self.sock.send(header + masked)
+
+    def recv(self):
+        hdr = self._recv_exact(2)
+        opcode = hdr[0] & 0x0F
+        if opcode == 0x8:
+            return b''
+        length = hdr[1] & 0x7F
+        if length == 126:
+            length = struct.unpack('>H', self._recv_exact(2))[0]
+        elif length == 127:
+            length = struct.unpack('>Q', self._recv_exact(8))[0]
+        mask = None
+        if hdr[1] & 0x80:
+            mask = self._recv_exact(4)
+        data = self._recv_exact(length)
+        if mask:
+            data = bytes(b ^ mask[i % 4] for i, b in enumerate(data))
+        return data
+
+    def close(self):
+        try:
+            self.sock.close()
+        except Exception:
+            pass
+
+    def _recv_exact(self, size):
+        buf = b''
+        while len(buf) < size:
+            buf += self.sock.recv(size - len(buf))
+        return buf
+
+def connect(url):
+    if not url.startswith("ws://"):
+        raise ValueError("WebSocket URL must start with ws://")
+    url_no_scheme = url[5:]
+    if '/' in url_no_scheme:
+        host_part, path = url_no_scheme.split('/', 1)
+        path = '/' + path
+    else:
+        host_part = url_no_scheme
+        path = '/'
+    if ':' in host_part:
+        host, port = host_part.split(':', 1)
+        port = int(port)
+    else:
+        host = host_part
+        port = 80
+    addr = usocket.getaddrinfo(host, port)[0][-1]
+    sock = usocket.socket()
+    sock.connect(addr)
+    key = ubinascii.b2a_base64(urandom.getrandbits(128).to_bytes(16, 'big')).strip()
+    headers = (
+        'GET {path} HTTP/1.1\r\n'
+        'Host: {host}\r\n'
+        'Upgrade: websocket\r\n'
+        'Connection: Upgrade\r\n'
+        'Sec-WebSocket-Key: {key}\r\n'
+        'Sec-WebSocket-Version: 13\r\n\r\n'
+    ).format(path=path, host=host, key=key.decode())
+    sock.send(headers.encode())
+    # Read HTTP response
+    response = b''
+    while b"\r\n\r\n" not in response:
+        chunk = sock.recv(64)
+        if not chunk:
+            raise OSError('WebSocket handshake failed')
+        response += chunk
+    return WebSocket(sock)


### PR DESCRIPTION
## Summary
- enable linking to Origin server via new `/api/origin/enable` endpoint
- add minimal WebSocket client for MicroPython without SSL dependency
- expose origin link workflow in admin UI
- inline shared Origin server URL instead of per-board config

## Testing
- `python -m py_compile src/common/websocket_client.py src/common/backend.py src/sys11/systemConfig.py src/em/systemConfig.py src/wpc/systemConfig.py`


------
https://chatgpt.com/codex/tasks/task_e_688ab8b805d08330983337fcbe3b8cea