### PR TITLE
Handle missing origin server

### DIFF
--- a/docs/origin-server-spec.md
+++ b/docs/origin-server-spec.md
@@ -1,0 +1,74 @@
+# Origin Server Specification
+
+This document describes the HTTP and WebSocket interfaces required for the Origin server used by Vector machines.  The server will
+be implemented with FastAPI and deployed in a Docker container.
+
+## Overview
+
+Vector devices call the Origin server to establish a shared secret and receive a claim link.  The server must expose a WebSocket
+endpoint for the initial handshake and REST endpoints for claiming and status checks.
+
+## WebSocket: `/ws/claim`
+
+Establishes a shared secret between the device and Origin.
+
+### Client → Server
+- Connect to `ws://<origin-host>/ws/claim`.
+- Send JSON payload: `{ "client_key": "<base64 x25519 public key>" }`.
+
+### Server Behaviour
+1. Generate an x25519 key pair.
+2. Compute shared secret using the device key.
+3. Create a unique `machine_id` (UUID) and a one-time `claim_code` (8–12 character alphanumeric).
+4. Sign the shared secret with the RSA private key matching the public key baked into the device firmware.
+5. Persist `{machine_id, claim_code, shared_secret, claimed=False}` in storage.
+
+### Server → Client
+Return JSON:
+```json
+{
+  "server_key": "<base64 server public key>",
+  "claim_code": "<claim code>",
+  "machine_id": "<uuid>",
+  "signature": "<hex RSA signature of shared_secret>"
+}
+```
+Close the socket afterwards.
+
+### Error Handling
+- Malformed JSON → close connection.
+- Internal errors → close connection and log; device should retry later.
+
+## HTTP: `GET /claim`
+Displays a web page that allows a user to claim a machine using the `claim_code`.
+
+- Query parameter: `code` (required).
+- Validate code; if invalid or already claimed return `404`.
+- On success, render HTML with device information and a button to confirm claiming.
+
+## HTTP: `POST /api/claim`
+Programmatic endpoint for completing a claim.
+
+- Request body: `{ "code": "<claim_code>", "user_id": "<user identifier>" }`.
+- Validate code and associate `machine_id` with the user.
+- Mark record as claimed and clear claim_code.
+- Responses:
+  - `204 No Content` on success
+  - `404` if code not found
+  - `409` if code already claimed
+
+## HTTP: `GET /api/machines/{machine_id}/status`
+Returns linking status for a machine so the device can poll.
+
+- Response when claimed: `{ "linked": true }`
+- Response when unclaimed or unknown: `{ "linked": false }`
+
+## Security Considerations
+- All HTTP endpoints served over HTTPS.
+- The RSA key pair used for signing must be kept private; the public key is embedded in device firmware.
+- Shared secrets are stored securely and will later be used to authenticate device communications (e.g., via HMAC headers).
+
+## Docker Notes
+- Base image: `python:3.11-slim`.
+- Install dependencies: `fastapi`, `uvicorn[standard]`, `websockets`, `cryptography`.
+- Expose port `80` and run `uvicorn` on startup.

--- a/tests/test_origin_enable.py
+++ b/tests/test_origin_enable.py
@@ -1,0 +1,53 @@
+import ast
+import sys
+import types
+
+# Define decorator stub
+add_route = lambda *args, **kwargs: (lambda f: f)
+
+# Stub modules used inside function
+sys.modules['ubinascii'] = types.ModuleType('ubinascii')
+sys.modules['ubinascii'].b2a_base64 = lambda x: b''
+sys.modules['ubinascii'].a2b_base64 = lambda x: b''
+sys.modules['ubinascii'].unhexlify = lambda x: b''
+
+sys.modules['ujson'] = types.ModuleType('ujson')
+sys.modules['ujson'].dumps = lambda *args, **kwargs: ''
+sys.modules['ujson'].loads = lambda s: {}
+
+sys.modules['curve25519'] = types.SimpleNamespace(generate_x25519_keypair=lambda: (None, None))
+
+rsa_module = types.ModuleType('rsa')
+rsa_module.key = types.SimpleNamespace(PublicKey=lambda **kwargs: None)
+rsa_module.pkcs1 = types.SimpleNamespace(verify=lambda *args, **kwargs: None)
+sys.modules['rsa'] = rsa_module
+sys.modules['rsa.key'] = rsa_module.key
+sys.modules['rsa.pkcs1'] = rsa_module.pkcs1
+
+ws_module = types.ModuleType('websocket_client')
+def fake_connect(url):
+    raise Exception('connection failed')
+ws_module.connect = fake_connect
+sys.modules['websocket_client'] = ws_module
+
+# Load backend.py and extract app_enable_origin
+with open('src/common/backend.py', 'r') as f:
+    source = f.read()
+module_ast = ast.parse(source)
+func_node = None
+for node in module_ast.body:
+    if isinstance(node, ast.FunctionDef) and node.name == 'app_enable_origin':
+        func_node = node
+        break
+assert func_node is not None
+module = ast.Module([func_node], type_ignores=[])
+code = compile(module, filename='app_enable_origin', mode='exec')
+namespace = {'add_route': add_route}
+exec(code, namespace)
+app_enable_origin = namespace['app_enable_origin']
+
+
+def test_enable_origin_unreachable():
+    result, status = app_enable_origin({})
+    assert status == 503
+    assert result['error'] == 'unreachable'


### PR DESCRIPTION
## Summary
- Improve `/api/origin/enable` to handle unreachable Origin service and handshake failures
- Specify required API for upcoming Origin server
- Add regression test for origin enable error path

## Testing
- `pytest tests/test_origin_enable.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688acb33f7508330aad05f8b9979ce39