### PR TITLE
Add midnight madness controls to admin UI

### DIFF
--- a/src/common/backend.py
+++ b/src/common/backend.py
@@ -639,6 +639,36 @@ def app_setShowIP(request):
     displayMessage.refresh()
 
 
+@add_route("/api/time/get_midnight_madness")
+def app_getMidnightMadness(request):
+    record = ds_read_record("extras", 0)
+    return {
+        "enabled": record["WPCTimeOn"],
+        "always": record["MM_Always"],
+    }
+
+
+@add_route("/api/time/set_midnight_madness", auth=True)
+def app_setMidnightMadness(request):
+    data = request.data
+    record = ds_read_record("extras", 0)
+    if "enabled" in data:
+        record["WPCTimeOn"] = bool(data["enabled"])
+    if "always" in data:
+        record["MM_Always"] = bool(data["always"])
+    ds_write_record("extras", record, 0)
+    from wpc.Time import intiialize
+
+    intiialize()
+
+
+@add_route("/api/time/trigger_midnight_madness", auth=True)
+def app_triggerMidnightMadness(request):
+    from wpc.Time import trigger_midnight_madness
+
+    trigger_midnight_madness()
+
+
 @add_route("/api/settings/factory_reset", auth=True)
 def app_factoryReset(request):
     import reset_control

--- a/src/common/web/html/admin.html
+++ b/src/common/web/html/admin.html
@@ -105,6 +105,34 @@
     </fieldset>
   </section>
   <section>
+    <h3>Midnight Madness</h3>
+    <fieldset id="midnight-madness-controls">
+      <label>
+        <input
+          id="midnight-madness-enable-toggle"
+          type="checkbox"
+          role="switch"
+          name="midnight-madness-enable"
+          disabled
+        />
+        <b>Enable Midnight Madness:</b> allow midnight madness features
+      </label>
+      <label>
+        <input
+          id="midnight-madness-always-toggle"
+          type="checkbox"
+          role="switch"
+          name="midnight-madness-always"
+          disabled
+        />
+        <b>Always Trigger:</b> start midnight madness every game
+      </label>
+      <button id="midnight-madness-now-button" disabled>
+        Trigger Midnight Madness Now
+      </button>
+    </fieldset>
+  </section>
+  <section>
     <h3>Adjustments Profiles</h3>
     <div id="adjustments-not-supported" class="hide">
       Adjustment profiles are not yet supported for this game or rom. If you

--- a/src/common/web/js/admin.js
+++ b/src/common/web/js/admin.js
@@ -117,9 +117,62 @@ async function getShowIP() {
   });
 }
 
+// Midnight Madness settings
+async function getMidnightMadness() {
+  const response = await window.smartFetch(
+    "/api/time/get_midnight_madness",
+    null,
+    false,
+  );
+  const data = await response.json();
+
+  const enableToggle = document.getElementById(
+    "midnight-madness-enable-toggle",
+  );
+  const alwaysToggle = document.getElementById(
+    "midnight-madness-always-toggle",
+  );
+  const nowButton = document.getElementById(
+    "midnight-madness-now-button",
+  );
+
+  enableToggle.checked = data["enabled"];
+  alwaysToggle.checked = data["always"];
+
+  enableToggle.disabled = false;
+  alwaysToggle.disabled = false;
+  nowButton.disabled = false;
+
+  function addListener(toggle) {
+    toggle.addEventListener("change", async () => {
+      const payload = {
+        enabled: enableToggle.checked ? 1 : 0,
+        always: alwaysToggle.checked ? 1 : 0,
+      };
+      await window.smartFetch(
+        "/api/time/set_midnight_madness",
+        payload,
+        true,
+      );
+    });
+  }
+
+  addListener(enableToggle);
+  addListener(alwaysToggle);
+
+  nowButton.addEventListener("click", async () => {
+    await window.smartFetch(
+      "/api/time/trigger_midnight_madness",
+      null,
+      true,
+    );
+  });
+}
+
 tournamentModeToggle();
 getScoreClaimMethods();
 getShowIP();
+getMidnightMadness();
 
 //
 // Adjustment Profiles


### PR DESCRIPTION
## Summary
- Add Midnight Madness section to admin page with enable and always-on toggles plus trigger button
- Wire new UI elements to backend via JavaScript
- Expose placeholder backend routes for Midnight Madness settings and trigger

## Testing
- `pytest` *(fails: No module named 'uctypes')*


------
https://chatgpt.com/codex/tasks/task_e_688ad563a2448330ac8ccd405ba64223