### PR TITLE
Fix Origin WebSocket handshake for MicroPython

### DIFF
--- a/src/common/websocket_client.py
+++ b/src/common/websocket_client.py
@@ -23,7 +23,7 @@ class WebSocket:
         else:
             header.append(0x80 | 127)
             header.extend(struct.pack('>Q', length))
-        mask = urandom.getrandbits(32).to_bytes(4, 'big')
+        mask = bytes(urandom.getrandbits(8) for _ in range(4))
         header.extend(mask)
         masked = bytes(b ^ mask[i % 4] for i, b in enumerate(data))
         self.sock.send(header + masked)
@@ -77,7 +77,8 @@ def connect(url):
     addr = usocket.getaddrinfo(host, port)[0][-1]
     sock = usocket.socket()
     sock.connect(addr)
-    key = ubinascii.b2a_base64(urandom.getrandbits(128).to_bytes(16, 'big')).strip()
+    key_bytes = bytes(urandom.getrandbits(8) for _ in range(16))
+    key = ubinascii.b2a_base64(key_bytes).strip()
     headers = (
         'GET {path} HTTP/1.1\r\n'
         'Host: {host}\r\n'

--- a/tests/test_websocket_client.py
+++ b/tests/test_websocket_client.py
@@ -1,0 +1,69 @@
+import sys
+import types
+import base64
+import os
+
+# Ensure module can be imported
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src', 'common'))
+# Provide stub modules so websocket_client can be imported on CPython
+sys.modules.setdefault('usocket', types.SimpleNamespace())
+sys.modules.setdefault('ubinascii', types.SimpleNamespace(b2a_base64=lambda b: base64.b64encode(b)))
+sys.modules.setdefault('urandom', types.SimpleNamespace(getrandbits=lambda n: 0))
+import websocket_client
+
+
+def _fake_usocket():
+    class DummySocket:
+        def __init__(self):
+            self.sent = []
+            self._done = False
+        def connect(self, addr):
+            self.addr = addr
+        def send(self, data):
+            self.sent.append(data)
+        def recv(self, n):
+            if not self._done:
+                self._done = True
+                return b"HTTP/1.1 101 Switching Protocols\r\n\r\n"
+            return b""
+        def close(self):
+            pass
+    return types.SimpleNamespace(
+        getaddrinfo=lambda host, port: [(None, None, None, None, ('0.0.0.0', port))],
+        socket=lambda: DummySocket(),
+    )
+
+
+def test_connect_does_not_request_large_bit_counts(monkeypatch):
+    calls = []
+    def fake_getrandbits(n):
+        calls.append(n)
+        if n > 32:
+            raise ValueError("bits must be 32 or less")
+        return 0
+    monkeypatch.setattr(websocket_client, 'urandom', types.SimpleNamespace(getrandbits=fake_getrandbits))
+    monkeypatch.setattr(websocket_client, 'usocket', _fake_usocket())
+    monkeypatch.setattr(websocket_client, 'ubinascii', types.SimpleNamespace(b2a_base64=lambda b: base64.b64encode(b)))
+
+    ws = websocket_client.connect("ws://example")
+    assert isinstance(ws, websocket_client.WebSocket)
+    assert max(calls) <= 32
+
+
+def test_send_uses_small_random_mask(monkeypatch):
+    calls = []
+    def fake_getrandbits(n):
+        calls.append(n)
+        if n > 32:
+            raise ValueError("bits must be 32 or less")
+        return 0
+    monkeypatch.setattr(websocket_client, 'urandom', types.SimpleNamespace(getrandbits=fake_getrandbits))
+    class DummySock:
+        def __init__(self):
+            self.sent = b''
+        def send(self, data):
+            self.sent = data
+    sock = DummySock()
+    ws = websocket_client.WebSocket(sock)
+    ws.send("hi")
+    assert max(calls) <= 32


### PR DESCRIPTION
## Summary
- avoid calling `urandom.getrandbits(128)` which exceeds MicroPython's limit
- derive WebSocket mask and key from 8-bit chunks instead
- add tests ensuring no `getrandbits` call exceeds 32 bits

## Testing
- `pytest tests/test_websocket_client.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688b6edb5b6c833082a86c4d74c3d244