### PR TITLE
Refresh discovery list on network sync

### DIFF
--- a/src/common/backend.py
+++ b/src/common/backend.py
@@ -779,7 +779,8 @@ def app_getAvailableSSIDs(request):
 def app_getPeers(request):
     from discovery import get_peer_map
 
-    return get_peer_map()
+    peers = get_peer_map()
+    return {ip: info for ip, info in peers.items() if not info["self"]}
 
 
 #

--- a/src/common/backend.py
+++ b/src/common/backend.py
@@ -6,6 +6,7 @@ from time import sleep, time
 
 import faults
 import Pico_Led
+import SharedState as S
 import uctypes
 from ls import ls
 from machine import RTC
@@ -15,8 +16,6 @@ from SPI_DataStore import memory_map as ds_memory_map
 from SPI_DataStore import read_record as ds_read_record
 from SPI_DataStore import write_record as ds_write_record
 from ujson import dumps as json_dumps
-
-import SharedState as S
 
 #
 # Constants
@@ -689,6 +688,7 @@ def app_midnightMadnessAvailable(request):
     else:
         return {"available": False}
 
+
 @add_route("/api/time/get_midnight_madness")
 def app_getMidnightMadness(request):
     record = ds_read_record("extras", 0)
@@ -696,6 +696,7 @@ def app_getMidnightMadness(request):
         "enabled": record.get("WPCTimeOn", False),
         "always": record.get("MM_Always", False),
     }
+
 
 @add_route("/api/time/set_midnight_madness", auth=True)
 def app_setMidnightMadness(request):
@@ -705,9 +706,11 @@ def app_setMidnightMadness(request):
     info["WPCTimeOn"] = bool(data["enabled"])
     ds_write_record("extras", info, 0)
 
+
 @add_route("/api/time/trigger_midnight_madness")
 def app_triggerMidnightMadness(request):
     import Time
+
     Time.trigger_midnight_madness()
 
 
@@ -774,9 +777,9 @@ def app_getAvailableSSIDs(request):
 
 @add_route("/api/network/peers")
 def app_getPeers(request):
-    from discovery import known_devices
+    from discovery import known_devices, local_ip_chars
 
-    return known_devices
+    return [d for d in known_devices if not d.startswith(local_ip_chars)]
 
 
 #

--- a/src/common/backend.py
+++ b/src/common/backend.py
@@ -777,9 +777,9 @@ def app_getAvailableSSIDs(request):
 
 @add_route("/api/network/peers")
 def app_getPeers(request):
-    from discovery import known_devices, local_ip_chars
+    from discovery import get_peer_map
 
-    return [d for d in known_devices if not d.startswith(local_ip_chars)]
+    return get_peer_map()
 
 
 #

--- a/src/common/discovery.py
+++ b/src/common/discovery.py
@@ -1,15 +1,15 @@
 # Network discovery utilities for Raspberry Pi Pico 2W boards
 # Implements a discovery request on boot and periodic refreshes.
 
-from time import time
 import socket
+from time import time
+
 from ujson import dumps, loads
 
 # The UDP port we will send/receive on
 DISCOVERY_PORT = 37020
-DEVICE_TIMEOUT = 60  # seconds before a device is considered gone
 DISCOVER_REFRESH = 600  # send a new discovery request every 10 minutes
-MAXIMUM_KNOWN_DEVICES = 10  # limit number of tracked devices
+MAXIMUM_KNOWN_DEVICES = 50  # limit number of tracked devices
 
 # Known devices keyed by 4 byte IP representation
 known_devices = {}
@@ -17,33 +17,35 @@ recv_sock = None
 send_sock = None
 last_discover_time = 0
 local_ip_bytes = None
+self_info = None
 
 
 def ip_to_bytes(ip_str: str) -> bytes:
     """Convert dotted-quad string to 4 byte representation."""
-    return socket.inet_aton(ip_str)
+    return bytes(int(part) for part in ip_str.split("."))
 
 
 def bytes_to_ip(ip_bytes: bytes) -> str:
     """Convert 4 byte IP representation back to dotted-quad string."""
-    return socket.inet_ntoa(ip_bytes)
+    return ".".join(str(b) for b in ip_bytes)
 
 
 def setup() -> None:
     """Initialise discovery state for this board."""
-    global known_devices, local_ip_bytes
+    global known_devices, local_ip_bytes, self_info
 
     from phew import get_ip_address
     from SharedState import gdata
     from systemConfig import SystemVersion
 
     local_ip_bytes = ip_to_bytes(get_ip_address())
-    known_devices[local_ip_bytes] = {
+    self_info = {
         "name": gdata["GameInfo"]["GameName"],
         "version": SystemVersion,
         "self": True,
     }
-    broadcast_discover()
+    known_devices = {local_ip_bytes: self_info}
+    refresh_known_devices()
 
 
 def send_intro(target_ip: bytes) -> None:
@@ -77,7 +79,6 @@ def broadcast_discover() -> None:
     except Exception as e:  # pragma: no cover - network errors are non-deterministic
         print("Failed to send discovery request:", e)
     last_discover_time = time()
-    prune_known_devices()
 
 
 def handle_message(msg: dict, ip_str: str) -> None:
@@ -88,12 +89,12 @@ def handle_message(msg: dict, ip_str: str) -> None:
 
     if msg.get("discover"):
         send_intro(ip_bytes)
+        refresh_known_devices()
         return
 
     if "name" in msg and "version" in msg:
         known_devices[ip_bytes] = {
             "version": msg["version"],
-            "last_seen": time(),
             "name": msg["name"],
         }
         enforce_limit()
@@ -114,7 +115,6 @@ def listen() -> None:
         try:
             data, addr = recv_sock.recvfrom(1024)
         except OSError:
-            prune_known_devices()
             return
 
         try:
@@ -128,19 +128,15 @@ def listen() -> None:
 def maybe_discover() -> None:
     """Broadcast a discovery request if our refresh interval has elapsed."""
     if (time() - last_discover_time) >= DISCOVER_REFRESH:
-        broadcast_discover()
+        refresh_known_devices()
 
 
-def prune_known_devices() -> None:
-    """Remove devices that have not been seen recently."""
+def refresh_known_devices() -> None:
+    """Clear known devices and broadcast a discovery request."""
     global known_devices
 
-    now = time()
-    known_devices = {
-        ip: info
-        for ip, info in known_devices.items()
-        if info.get("self", False) or ("last_seen" in info and (now - info["last_seen"]) <= DEVICE_TIMEOUT)
-    }
+    known_devices = {local_ip_bytes: self_info}
+    broadcast_discover()
 
 
 def enforce_limit() -> None:
@@ -151,22 +147,16 @@ def enforce_limit() -> None:
         return
 
     # Always keep the local device
-    local_info = known_devices.get(local_ip_bytes)
-    others = [
-        (ip, info)
-        for ip, info in known_devices.items()
-        if ip != local_ip_bytes
-    ]
-    # Keep the most recently seen others
-    others.sort(key=lambda item: item[1]["last_seen"], reverse=True)
-
-    new_known = {local_ip_bytes: local_info}
-    for ip, info in others[: MAXIMUM_KNOWN_DEVICES - 1]:
+    new_known = {local_ip_bytes: known_devices.get(local_ip_bytes)}
+    for ip, info in known_devices.items():
+        if ip == local_ip_bytes:
+            continue
         new_known[ip] = info
+        if len(new_known) >= MAXIMUM_KNOWN_DEVICES:
+            break
     known_devices = new_known
 
 
 def debug_known_devices() -> None:  # pragma: no cover - debugging helper
     printable = {bytes_to_ip(ip): info for ip, info in known_devices.items()}
     print("Known devices:", printable)
-

--- a/src/common/discovery.py
+++ b/src/common/discovery.py
@@ -232,10 +232,15 @@ def enforce_limit() -> None:
     del known_devices[MAXIMUM_KNOWN_DEVICES:]
 
 
-def debug_known_devices() -> None:  # pragma: no cover - debugging helper
-    printable = {}
+def get_peer_map() -> dict:
+    """Return mapping of known devices keyed by IP string."""
+    peers = {}
     for dev in known_devices:
         ip_chars, name = dev[:4], dev[4:]
         ip = bytes_to_ip(bytes(ord(c) for c in ip_chars))
-        printable[ip] = {"name": name}
-    print("Known devices:", printable)
+        peers[ip] = {"name": name, "self": ip_chars == local_ip_chars}
+    return peers
+
+
+def debug_known_devices() -> None:  # pragma: no cover - debugging helper
+    print("Known devices:", get_peer_map())

--- a/src/common/discovery.py
+++ b/src/common/discovery.py
@@ -8,6 +8,7 @@ from ujson import dumps, loads
 
 # The UDP port we will send/receive on
 DISCOVERY_PORT = 37020
+DEVICE_TIMEOUT = 60  # seconds before a device is considered gone
 DISCOVER_REFRESH = 600  # send a new discovery request every 10 minutes
 MAXIMUM_KNOWN_DEVICES = 50  # limit number of tracked devices
 
@@ -64,6 +65,21 @@ def send_intro(target_ip: bytes) -> None:
         send_sock.sendto(dumps(msg).encode("utf-8"), (bytes_to_ip(target_ip), DISCOVERY_PORT))
     except Exception as e:  # pragma: no cover - network errors are non-deterministic
         print("Failed to send intro:", e)
+
+
+def announce() -> None:
+    """Broadcast this device's information to the local network."""
+    global send_sock
+
+    if not send_sock:
+        send_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        send_sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+
+    msg = {"name": self_info["name"], "version": self_info["version"]}
+    try:
+        send_sock.sendto(dumps(msg).encode("utf-8"), ("255.255.255.255", DISCOVERY_PORT))
+    except Exception as e:  # pragma: no cover - network errors are non-deterministic
+        print("Failed to broadcast announcement:", e)
 
 
 def broadcast_discover() -> None:

--- a/src/common/phew/server.py
+++ b/src/common/phew/server.py
@@ -280,7 +280,7 @@ def create_schedule(ap_mode: bool = False):
     from resource import go as resource_go
 
     from backend import connect_to_wifi
-    from discovery import DEVICE_TIMEOUT, announce, listen
+    from discovery import announce, listen
     from displayMessage import refresh
     from GameStatus import poll_fast
 
@@ -325,11 +325,11 @@ def create_schedule(ap_mode: bool = False):
 
     # non AP mode only tasks
     if not ap_mode:
-        # every 1/2 of DEVICE_TIMEOUT announce our presence
-        schedule(announce, 10000, DEVICE_TIMEOUT * 1000 // 2)
+        # announce our presence every 30 seconds
+        schedule(announce, 10000, 30000)
 
-        # every 1/20 of DEVICE_TIMEOUT listen for others
-        schedule(listen, 10000, DEVICE_TIMEOUT * 1000 // 20)
+        # listen for others every 3 seconds
+        schedule(listen, 10000, 3000)
 
         # initialize the time and date 5 seconds after boot
         schedule(initialize_timedate, 5000, log="Server: Initialize time /date")

--- a/src/common/phew/server.py
+++ b/src/common/phew/server.py
@@ -325,17 +325,17 @@ def create_schedule(ap_mode: bool = False):
 
     # non AP mode only tasks
     if not ap_mode:
-        # announce our presence every 30 seconds
-        schedule(broadcast_hello, 10000, 30000)
+        # announce our presence once after boot
+        schedule(broadcast_hello, 10000)
 
-        # listen for others every 3 seconds
-        schedule(listen, 10000, 3000)
+        # listen for others every 2 seconds
+        schedule(listen, 10000, 2000)
 
         # periodically refresh the peer list
         schedule(maybe_discover, 10000, 60000)
 
         # ping peers to detect offline devices
-        schedule(ping_random_peer, 12000, 15000)
+        schedule(ping_random_peer, 12000, 5000)
 
         # initialize the time and date 5 seconds after boot
         schedule(initialize_timedate, 5000, log="Server: Initialize time /date")

--- a/src/common/phew/server.py
+++ b/src/common/phew/server.py
@@ -280,7 +280,7 @@ def create_schedule(ap_mode: bool = False):
     from resource import go as resource_go
 
     from backend import connect_to_wifi
-    from discovery import announce, listen
+    from discovery import broadcast_hello, check_pending_pings, listen, ping_random_peer
     from displayMessage import refresh
     from GameStatus import poll_fast
 
@@ -326,10 +326,14 @@ def create_schedule(ap_mode: bool = False):
     # non AP mode only tasks
     if not ap_mode:
         # announce our presence every 30 seconds
-        schedule(announce, 10000, 30000)
+        schedule(broadcast_hello, 10000, 30000)
 
         # listen for others every 3 seconds
         schedule(listen, 10000, 3000)
+
+        # ping peers and check for offline devices
+        schedule(ping_random_peer, 12000, 15000)
+        schedule(check_pending_pings, 12000, 5000)
 
         # initialize the time and date 5 seconds after boot
         schedule(initialize_timedate, 5000, log="Server: Initialize time /date")

--- a/src/common/phew/server.py
+++ b/src/common/phew/server.py
@@ -280,7 +280,7 @@ def create_schedule(ap_mode: bool = False):
     from resource import go as resource_go
 
     from backend import connect_to_wifi
-    from discovery import broadcast_hello, listen, maybe_discover, ping_random_peer
+    from discovery import anyone_out_there, broadcast_hello, listen, ping_random_peer
     from displayMessage import refresh
     from GameStatus import poll_fast
 
@@ -326,16 +326,16 @@ def create_schedule(ap_mode: bool = False):
     # non AP mode only tasks
     if not ap_mode:
         # announce our presence once after boot
-        schedule(broadcast_hello, 10000)
+        schedule(broadcast_hello, 5000)
 
         # listen for others every 2 seconds
-        schedule(listen, 10000, 2000)
-
-        # periodically refresh the peer list
-        schedule(maybe_discover, 10000, 60000)
+        schedule(listen, 4900, 2000)
 
         # ping peers to detect offline devices
         schedule(ping_random_peer, 12000, 5000)
+
+        # periodically refresh the peer list (if we're the registry)
+        schedule(anyone_out_there, 10000, 60000)
 
         # initialize the time and date 5 seconds after boot
         schedule(initialize_timedate, 5000, log="Server: Initialize time /date")

--- a/src/common/phew/server.py
+++ b/src/common/phew/server.py
@@ -280,7 +280,7 @@ def create_schedule(ap_mode: bool = False):
     from resource import go as resource_go
 
     from backend import connect_to_wifi
-    from discovery import broadcast_hello, check_pending_pings, listen, ping_random_peer
+    from discovery import broadcast_hello, listen, maybe_discover, ping_random_peer
     from displayMessage import refresh
     from GameStatus import poll_fast
 
@@ -331,9 +331,11 @@ def create_schedule(ap_mode: bool = False):
         # listen for others every 3 seconds
         schedule(listen, 10000, 3000)
 
-        # ping peers and check for offline devices
+        # periodically refresh the peer list
+        schedule(maybe_discover, 10000, 60000)
+
+        # ping peers to detect offline devices
         schedule(ping_random_peer, 12000, 15000)
-        schedule(check_pending_pings, 12000, 5000)
 
         # initialize the time and date 5 seconds after boot
         schedule(initialize_timedate, 5000, log="Server: Initialize time /date")

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -79,6 +79,17 @@ def test_handle_pong_clears_pending_ping():
     assert discovery.pending_ping is None
 
 
+def test_offline_for_self_triggers_hello(monkeypatch):
+    called = {}
+
+    def fake_hello():
+        called["hello"] = True
+
+    monkeypatch.setattr(discovery, "broadcast_hello", fake_hello)
+    discovery.handle_message({"offline": "192.168.0.10"}, "192.168.0.20")
+    assert called.get("hello")
+
+
 def test_ping_marks_offline_on_next_call(monkeypatch):
     peer_ip = "192.168.0.20"
     ip_chars = _ip_chars(peer_ip)
@@ -139,6 +150,7 @@ def test_broadcast_full_list_packs_payload():
     parts = msg["full"].split("|")
     assert parts[0] == _ip_chars("192.168.0.10") + "local"
     assert parts[1] == _ip_chars("192.168.0.20") + "Peer"
+    assert addr == ("255.255.255.255", discovery.DISCOVERY_PORT)
 
 
 def test_add_or_update_keeps_sorted():

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -148,3 +148,11 @@ def test_refresh_known_devices_passes_delay(monkeypatch):
     monkeypatch.setattr(discovery, "broadcast_discover", lambda: None)
     discovery.refresh_known_devices()
     assert captured["delay"] == 0.5
+
+
+def test_get_peer_map_includes_self_and_peers():
+    peer_ip_chars = "".join(chr(b) for b in discovery.ip_to_bytes("192.168.0.20"))
+    discovery.known_devices.append(peer_ip_chars + "Peer")
+    mapping = discovery.get_peer_map()
+    assert mapping["192.168.0.10"] == {"name": "local", "self": True}
+    assert mapping["192.168.0.20"] == {"name": "Peer", "self": False}

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -139,3 +139,11 @@ def test_broadcast_full_list_packs_payload():
     parts = msg["full"].split("|")
     assert parts[0] == _ip_chars("192.168.0.10") + "local"
     assert parts[1] == _ip_chars("192.168.0.20") + "Peer"
+
+
+def test_add_or_update_keeps_sorted():
+    discovery._add_or_update(_ip_chars("192.168.0.20"), "A")
+    discovery._add_or_update(_ip_chars("192.168.0.5"), "B")
+    discovery._add_or_update(_ip_chars("192.168.0.30"), "C")
+    ips = [d[:4] for d in discovery.known_devices]
+    assert ips == [_ip_chars("192.168.0.5"), _ip_chars("192.168.0.20"), _ip_chars("192.168.0.30")]


### PR DESCRIPTION
## Summary
- rebuild discovery table from scratch every refresh
- handle discovery requests by re-syncing known devices
- raise MAXIMUM_KNOWN_DEVICES to 50 and fix IP conversion without inet_aton

## Testing
- `pre-commit run --files src/common/discovery.py tests/test_discovery.py`
- `pytest tests/test_discovery.py`


------
https://chatgpt.com/codex/tasks/task_e_6896481d42d883309eb03f60c3470c25