### PR TITLE
Encode discovery messages in compact binary

### DIFF
--- a/src/common/discovery.py
+++ b/src/common/discovery.py
@@ -6,9 +6,12 @@
 # new devices arrive or when peers are marked offline.
 
 import socket
-from dataclasses import dataclass
-from typing import Generator, Iterable, Optional, Tuple
 from random import choice
+
+try:  # MicroPython may lack the ``typing`` module
+    from typing import Generator, Iterable, Optional, Tuple
+except ImportError:  # pragma: no cover - fallback for MicroPython
+    Generator = Iterable = Optional = Tuple = None  # type: ignore
 
 
 class MessageType:
@@ -44,14 +47,18 @@ local_ip_chars = ""
 # Track a single peer we're awaiting a pong from
 pending_ping = None
 
-@dataclass
 class DiscoveryMessage:
     """Structured discovery message with compact binary encoding."""
 
-    type: int
-    name: Optional[str] = None
-    peers: Optional[Iterable[Tuple[str, str]]] = None
-    ip: Optional[bytes] = None
+    __slots__ = ("type", "name", "peers", "ip")
+
+    def __init__(self, mtype: int, name: Optional[str] = None,
+                 peers: Optional[Iterable[Tuple[str, str]]] = None,
+                 ip: Optional[bytes] = None) -> None:
+        self.type = mtype
+        self.name = name
+        self.peers = peers
+        self.ip = ip
 
     @classmethod
     def hello(cls, name: str) -> "DiscoveryMessage":

--- a/src/common/discovery.py
+++ b/src/common/discovery.py
@@ -6,14 +6,20 @@
 # new devices arrive or when peers are marked offline.
 
 import socket
+from enum import IntEnum
+from dataclasses import dataclass
+from typing import Generator, Iterable, Optional, Tuple
 from random import choice
 
-# Message type identifiers for compact binary encoding
-HELLO = 1
-FULL = 2
-PING = 3
-PONG = 4
-OFFLINE = 5
+
+class MessageType(IntEnum):
+    """Types of discovery messages."""
+
+    HELLO = 1
+    FULL = 2
+    PING = 3
+    PONG = 4
+    OFFLINE = 5
 
 # UDP port used for discovery traffic
 DISCOVERY_PORT = 37020
@@ -39,86 +45,109 @@ local_ip_chars = ""
 # Track a single peer we're awaiting a pong from
 pending_ping = None
 
+@dataclass
+class DiscoveryMessage:
+    """Structured discovery message with compact binary encoding."""
 
-def encode_message(msg: dict) -> bytes:
-    """Encode a discovery ``msg`` dictionary into a compact binary format."""
+    type: MessageType
+    name: Optional[str] = None
+    peers: Optional[Iterable[Tuple[str, str]]] = None
+    ip: Optional[str] = None
 
-    if msg.get("hello"):
-        name = str(msg.get("name", ""))[:MAX_NAME_LENGTH]
-        name_bytes = name.encode("utf-8")
-        return bytes([HELLO, len(name_bytes)]) + name_bytes
+    @classmethod
+    def hello(cls, name: str) -> "DiscoveryMessage":
+        return cls(MessageType.HELLO, name=name)
 
-    if msg.get("full"):
-        payload = str(msg["full"])
-        peers = [p for p in payload.split("|") if p]
-        parts = [bytes([FULL, len(peers)])]
-        for peer in peers:
-            if len(peer) < 4:
-                continue
-            ip_part = bytes(ord(c) for c in peer[:4])
-            name_bytes = peer[4:].encode("utf-8")[:MAX_NAME_LENGTH]
-            parts.append(ip_part + bytes([len(name_bytes)]) + name_bytes)
-        return b"".join(parts)
+    @classmethod
+    def full(cls, peers: Iterable[Tuple[str, str]]) -> "DiscoveryMessage":
+        return cls(MessageType.FULL, peers=peers)
 
-    if msg.get("ping"):
-        return bytes([PING])
+    @classmethod
+    def ping(cls) -> "DiscoveryMessage":
+        return cls(MessageType.PING)
 
-    if msg.get("pong"):
-        return bytes([PONG])
+    @classmethod
+    def pong(cls) -> "DiscoveryMessage":
+        return cls(MessageType.PONG)
 
-    if msg.get("offline"):
-        ip_bytes = ip_to_bytes(msg["offline"])
-        return bytes([OFFLINE]) + ip_bytes
+    @classmethod
+    def offline(cls, ip: str) -> "DiscoveryMessage":
+        return cls(MessageType.OFFLINE, ip=ip)
 
-    raise ValueError("Unknown message type")
+    # ------------------------------------------------------------------ encoding
+    def encode(self) -> bytes:
+        if self.type is MessageType.HELLO and self.name is not None:
+            name_bytes = self.name[:MAX_NAME_LENGTH].encode("utf-8")
+            return bytes([MessageType.HELLO, len(name_bytes)]) + name_bytes
 
+        if self.type is MessageType.FULL and self.peers is not None:
+            peers_list = list(self.peers)
+            parts = [bytes([MessageType.FULL, len(peers_list)])]
+            for ip_chars, name in peers_list:
+                ip_part = bytes(ord(c) for c in ip_chars[:4])
+                name_bytes = name[:MAX_NAME_LENGTH].encode("utf-8")
+                parts.append(ip_part + bytes([len(name_bytes)]) + name_bytes)
+            return b"".join(parts)
 
-def decode_message(data: bytes) -> dict | None:
-    """Decode binary ``data`` into a discovery message dictionary."""
+        if self.type is MessageType.PING:
+            return bytes([MessageType.PING])
 
-    if not data:
-        return None
-    mtype = data[0]
-    if mtype == HELLO:
-        if len(data) < 2:
+        if self.type is MessageType.PONG:
+            return bytes([MessageType.PONG])
+
+        if self.type is MessageType.OFFLINE and self.ip is not None:
+            return bytes([MessageType.OFFLINE]) + ip_to_bytes(self.ip)
+
+        raise ValueError("Incomplete message for encoding")
+
+    # ------------------------------------------------------------------ decoding
+    @staticmethod
+    def decode(data: bytes) -> Optional["DiscoveryMessage"]:
+        if not data:
             return None
-        name_len = data[1]
-        name = data[2 : 2 + name_len].decode("utf-8", "ignore")
-        return {"hello": True, "name": name}
+        mtype = MessageType(data[0])
 
-    if mtype == FULL:
-        if len(data) < 2:
-            return None
-        count = data[1]
-        offset = 2
-        peers = []
-        for _ in range(count):
-            if len(data) < offset + 5:
+        if mtype is MessageType.HELLO:
+            if len(data) < 2:
                 return None
-            ip_part = data[offset : offset + 4]
-            offset += 4
-            name_len = data[offset]
-            offset += 1
-            name = data[offset : offset + name_len].decode("utf-8", "ignore")
-            offset += name_len
-            ip_chars = "".join(chr(b) for b in ip_part)
-            peers.append(ip_chars + name)
-        return {"full": "|".join(peers)}
+            name_len = data[1]
+            name = data[2 : 2 + name_len].decode("utf-8", "ignore")
+            return DiscoveryMessage(MessageType.HELLO, name=name)
 
-    if mtype == PING:
-        return {"ping": True}
+        if mtype is MessageType.FULL:
+            if len(data) < 2:
+                return None
+            count = data[1]
 
-    if mtype == PONG:
-        return {"pong": True}
+            def peer_gen() -> Generator[Tuple[str, str], None, None]:
+                offset = 2
+                for _ in range(count):
+                    if len(data) < offset + 5:
+                        return
+                    ip_part = data[offset : offset + 4]
+                    offset += 4
+                    name_len = data[offset]
+                    offset += 1
+                    name = data[offset : offset + name_len].decode("utf-8", "ignore")
+                    offset += name_len
+                    ip_chars = "".join(chr(b) for b in ip_part)
+                    yield ip_chars, name
 
-    if mtype == OFFLINE:
-        if len(data) < 5:
-            return None
-        ip_str = bytes_to_ip(data[1:5])
-        return {"offline": ip_str}
+            return DiscoveryMessage(MessageType.FULL, peers=peer_gen())
 
-    return None
+        if mtype is MessageType.PING:
+            return DiscoveryMessage(MessageType.PING)
 
+        if mtype is MessageType.PONG:
+            return DiscoveryMessage(MessageType.PONG)
+
+        if mtype is MessageType.OFFLINE:
+            if len(data) < 5:
+                return None
+            ip_str = bytes_to_ip(data[1:5])
+            return DiscoveryMessage(MessageType.OFFLINE, ip=ip_str)
+
+        return None
 
 def ip_to_bytes(ip_str: str) -> bytes:
     """Convert dotted-quad string to a 4-byte representation."""
@@ -153,7 +182,7 @@ def setup() -> None:
     broadcast_hello()
 
 
-def _send(msg: dict, addr: tuple = ("255.255.255.255", DISCOVERY_PORT)) -> None:
+def _send(msg: DiscoveryMessage, addr: tuple = ("255.255.255.255", DISCOVERY_PORT)) -> None:
     print(f"DISCOVERY:Sending message to {addr}: {msg}")
 
     global send_sock
@@ -161,21 +190,21 @@ def _send(msg: dict, addr: tuple = ("255.255.255.255", DISCOVERY_PORT)) -> None:
         send_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         send_sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
     try:  # pragma: no cover - network errors are non-deterministic
-        send_sock.sendto(encode_message(msg), addr)
+        send_sock.sendto(msg.encode(), addr)
     except Exception:
         pass
 
 
 def broadcast_hello() -> None:
     """Broadcast that this device has joined the network."""
-    _send({"hello": True, "name": _get_local_name()})
+    _send(DiscoveryMessage.hello(_get_local_name()))
 
 
 def broadcast_full_list() -> None:
     """Broadcast the full list of known devices."""
 
-    payload = "|".join([local_ip_chars + _get_local_name()] + known_devices)
-    _send({"full": payload})
+    peers = [(local_ip_chars, _get_local_name())] + [(d[:4], d[4:]) for d in known_devices]
+    _send(DiscoveryMessage.full(peers))
 
 
 def registry_ip_bytes() -> bytes:
@@ -220,7 +249,7 @@ def registry_should_broadcast():
             pending_ping = registry_ip_bytes()
 
 
-def handle_message(msg: dict, ip_str: str) -> None:
+def handle_message(msg: DiscoveryMessage, ip_str: str) -> None:
     """Handle an incoming message from ``ip_str``."""
     print(f"DISCOVERY: Received message from {ip_str}: {msg}")
     global pending_ping, known_devices, local_ip_bytes, local_ip_chars
@@ -228,19 +257,19 @@ def handle_message(msg: dict, ip_str: str) -> None:
     ip_bytes = ip_to_bytes(ip_str)
     ip_chars = "".join(chr(b) for b in ip_bytes)
 
-    if msg.get("ping"):
-        _send({"pong": True}, (ip_str, DISCOVERY_PORT))
+    if msg.type is MessageType.PING:
+        _send(DiscoveryMessage.pong(), (ip_str, DISCOVERY_PORT))
         if ip_chars not in [d[:4] for d in known_devices]:
             broadcast_hello()
         return
 
-    if msg.get("pong"):
+    if msg.type is MessageType.PONG:
         if pending_ping == ip_bytes:
             pending_ping = None
         return
 
-    if msg.get("offline"):
-        off_ip = msg["offline"]
+    if msg.type is MessageType.OFFLINE and msg.ip is not None:
+        off_ip = msg.ip
         if off_ip == bytes_to_ip(local_ip_bytes):
             broadcast_hello()
             return
@@ -249,22 +278,15 @@ def handle_message(msg: dict, ip_str: str) -> None:
         registry_should_broadcast()
         return
 
-    if msg.get("hello"):
-        name = str(msg.get("name", ""))[:MAX_NAME_LENGTH]
+    if msg.type is MessageType.HELLO and msg.name is not None:
+        name = msg.name[:MAX_NAME_LENGTH]
         _add_or_update(ip_chars, name)
         registry_should_broadcast()
 
-    if msg.get("full"):
-        peers_str = msg["full"]
-        if not isinstance(peers_str, str):
-            return
-        peers = [p for p in peers_str.split("|") if p]
+    if msg.type is MessageType.FULL and msg.peers is not None:
         found_self = False
-        for peer in peers:
-            if len(peer) < 4:
-                continue
-            ip_chars_peer = peer[:4]
-            name = peer[4:][:MAX_NAME_LENGTH]
+        for ip_chars_peer, name in msg.peers:
+            name = name[:MAX_NAME_LENGTH]
             if ip_chars_peer == local_ip_chars:
                 found_self = True
             _add_or_update(ip_chars_peer, name)
@@ -287,7 +309,7 @@ def _recv():
         data, addr = recv_sock.recvfrom(1024)
     except OSError:
         return None, None
-    msg = decode_message(data)
+    msg = DiscoveryMessage.decode(data)
     return (msg, addr) if msg else (None, None)
 
 
@@ -324,7 +346,7 @@ def ping_random_peer() -> None:
         off_chars = "".join(chr(b) for b in pending_ping)
         known_devices = [d for d in known_devices if not d.startswith(off_chars)]
         ip_str = bytes_to_ip(pending_ping)
-        _send({"offline": ip_str})
+        _send(DiscoveryMessage.offline(ip_str))
         if is_registry():
             broadcast_full_list()
         pending_ping = None
@@ -333,5 +355,5 @@ def ping_random_peer() -> None:
         broadcast_hello()
     target = choice(peers)
     ip_bytes = bytes(ord(c) for c in target[:4])
-    _send({"ping": True}, (bytes_to_ip(ip_bytes), DISCOVERY_PORT))
+    _send(DiscoveryMessage.ping(), (bytes_to_ip(ip_bytes), DISCOVERY_PORT))
     pending_ping = ip_bytes

--- a/tests/test_discovery_encoding.py
+++ b/tests/test_discovery_encoding.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+# Ensure src directory is on sys.path
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from common.discovery import (
+    encode_message,
+    decode_message,
+)
+
+
+def _ip_chars(*bytes_):
+    return ''.join(chr(b) for b in bytes_)
+
+
+def test_encode_decode_hello():
+    msg = {"hello": True, "name": "Test"}
+    data = encode_message(msg)
+    assert decode_message(data) == msg
+
+
+def test_encode_decode_full():
+    p1 = _ip_chars(192, 168, 0, 1) + "dev1"
+    p2 = _ip_chars(192, 168, 0, 2) + "dev2"
+    payload = "|".join([p1, p2])
+    msg = {"full": payload}
+    data = encode_message(msg)
+    assert decode_message(data) == msg
+
+
+def test_encode_decode_ping_pong():
+    assert decode_message(encode_message({"ping": True})) == {"ping": True}
+    assert decode_message(encode_message({"pong": True})) == {"pong": True}
+
+
+def test_encode_decode_offline():
+    msg = {"offline": "192.168.0.5"}
+    data = encode_message(msg)
+    assert decode_message(data) == msg

--- a/tests/test_discovery_encoding.py
+++ b/tests/test_discovery_encoding.py
@@ -15,7 +15,7 @@ def test_encode_decode_hello():
     msg = DiscoveryMessage.hello("Test")
     data = msg.encode()
     decoded = DiscoveryMessage.decode(data)
-    assert decoded and decoded.type is MessageType.HELLO and decoded.name == "Test"
+    assert decoded and decoded.type == MessageType.HELLO and decoded.name == "Test"
 
 
 def test_encode_decode_full():
@@ -23,17 +23,18 @@ def test_encode_decode_full():
     msg = DiscoveryMessage.full(peers)
     data = msg.encode()
     decoded = DiscoveryMessage.decode(data)
-    assert decoded and decoded.type is MessageType.FULL
+    assert decoded and decoded.type == MessageType.FULL
     assert list(decoded.peers) == peers
 
 
 def test_encode_decode_ping_pong():
-    assert DiscoveryMessage.decode(DiscoveryMessage.ping().encode()).type is MessageType.PING
-    assert DiscoveryMessage.decode(DiscoveryMessage.pong().encode()).type is MessageType.PONG
+    assert DiscoveryMessage.decode(DiscoveryMessage.ping().encode()).type == MessageType.PING
+    assert DiscoveryMessage.decode(DiscoveryMessage.pong().encode()).type == MessageType.PONG
 
 
 def test_encode_decode_offline():
-    msg = DiscoveryMessage.offline("192.168.0.5")
+    ip = bytes([192, 168, 0, 5])
+    msg = DiscoveryMessage.offline(ip)
     data = msg.encode()
     decoded = DiscoveryMessage.decode(data)
-    assert decoded and decoded.type is MessageType.OFFLINE and decoded.ip == "192.168.0.5"
+    assert decoded and decoded.type == MessageType.OFFLINE and decoded.ip == ip


### PR DESCRIPTION
## Summary
- Replace JSON discovery messages with compact binary format
- Add helper encode/decode functions and update send/receive logic
- Add tests covering discovery message encoding round-trip

## Testing
- `pytest tests/test_discovery_encoding.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689813246b408330a3cf170a6921332e