### PR TITLE
Serve static files with gzip encoding

### DIFF
--- a/dev/build.py
+++ b/dev/build.py
@@ -199,23 +199,22 @@ class Builder:
 
     @step_report
     def zip_files(self):
-        """gzip all files in build/web subdirectories (but not build/web itself)."""
-        print("Zipping files in subdirectories...")
+        """gzip applicable files in build/web."""
+        print("Zipping web files...")
         web_dir = os.path.join(self.build_dir, "web")
         if not os.path.isdir(web_dir):
             print("No 'web' directory found; skipping zip step.")
             return
 
-        # zip each subdirectory (e.g. web/css, web/js, web/svg, etc.)
-        for item in os.listdir(web_dir):
-            item_path = os.path.join(web_dir, item)
-            if os.path.isdir(item_path):
-                self.gzip_directory(item_path)
+        self.gzip_directory(web_dir)
 
     def gzip_directory(self, directory):
         print(f"Gzipping files in {directory}...")
         for root, dirs, files in os.walk(directory):
             for file in files:
+                if file.endswith((".gz", ".svg")):
+                    # Skip existing gzip files and SVG images which remain plain XML
+                    continue
                 file_path = os.path.join(root, file)
                 with open(file_path, "rb") as f:
                     content = f.read()

--- a/src/common/backend.py
+++ b/src/common/backend.py
@@ -6,6 +6,7 @@ from time import sleep, time
 
 import faults
 import Pico_Led
+import SharedState as S
 import uctypes
 from ls import ls
 from machine import RTC
@@ -15,8 +16,6 @@ from SPI_DataStore import memory_map as ds_memory_map
 from SPI_DataStore import read_record as ds_read_record
 from SPI_DataStore import write_record as ds_write_record
 from ujson import dumps as json_dumps
-
-import SharedState as S
 
 #
 # Constants
@@ -119,6 +118,7 @@ def get_content_type(file_path):
         ".jpg": "image/jpeg",
         ".jpeg": "image/jpeg",
         ".gif": "image/gif",
+        ".svg": "image/svg+xml",
         ".gz": "application/gzip",
     }
     for extension, content_type in content_type_mapping.items():
@@ -128,43 +128,46 @@ def get_content_type(file_path):
 
 
 def create_file_handler(file_path):
-    # Compute ETag incrementally to save memory
+    is_gz = file_path.endswith(".gz")
+    served_path = file_path[:-3] if is_gz else file_path
+
     try:
         hasher = hashlib_sha256()
         with open(file_path, "rb") as f:
             buff = bytearray(1024)
             while True:
-                buff[0:] = f.read(1024)  # Read in 1KB chunks
+                buff[0:] = f.read(1024)
                 if not buff:
                     break
                 hasher.update(buff)
         etag = hexlify(hasher.digest()[:8]).decode()
     except Exception as e:
         print(f"Failed to calculate ETag for {file_path}: {e}")
-        etag = random_hex(8)  # Fallback to a random ETag
+        etag = random_hex(8)
 
     def file_stream_generator():
         gc_collect()
         with open(file_path, "rb") as f:
             buff = bytearray(1024)
             while True:
-                buff[0:] = f.read(1024)  # Read in 1KB chunks
+                buff[0:] = f.read(1024)
                 if not buff:
                     break
                 yield buff
         gc_collect()
 
     def file_handler(request):
-        # Check for conditional request
         if request.headers.get("if-none-match") == etag:
-            return "", 304, {"ETag": etag}  # Tell the browser to use it's cached copy
+            return "", 304, {"ETag": etag}
 
         headers = {
-            "Content-Type": get_content_type(file_path),
+            "Content-Type": get_content_type(served_path),
             "Connection": "close",
-            "Cache-Control": "public, max-age=31536000, immutable",  # Cache for 1 year, immutable
+            "Cache-Control": "public, max-age=31536000, immutable",
             "ETag": etag,
         }
+        if is_gz:
+            headers["Content-Encoding"] = "gzip"
         return file_stream_generator(), 200, headers
 
     return route_wrapper(file_handler)
@@ -343,10 +346,13 @@ def check_password(request):
 # Static File Server
 #
 for file_path in ls("web"):
-    route = file_path[3:]  # This should give '/index.html' for 'web/index.html'
-    phew_add_route(route, create_file_handler(file_path))
+    route = file_path[3:]
+    if file_path.endswith(".gz"):
+        route = route[:-3]
+    handler = create_file_handler(file_path)
+    phew_add_route(route, handler)
     if route == "/index.html":
-        phew_add_route("/", create_file_handler(file_path))
+        phew_add_route("/", handler)
 
 
 #
@@ -689,6 +695,7 @@ def app_midnightMadnessAvailable(request):
     else:
         return {"available": False}
 
+
 @add_route("/api/time/get_midnight_madness")
 def app_getMidnightMadness(request):
     record = ds_read_record("extras", 0)
@@ -696,6 +703,7 @@ def app_getMidnightMadness(request):
         "enabled": record.get("WPCTimeOn", False),
         "always": record.get("MM_Always", False),
     }
+
 
 @add_route("/api/time/set_midnight_madness", auth=True)
 def app_setMidnightMadness(request):
@@ -705,9 +713,11 @@ def app_setMidnightMadness(request):
     info["WPCTimeOn"] = bool(data["enabled"])
     ds_write_record("extras", info, 0)
 
+
 @add_route("/api/time/trigger_midnight_madness")
 def app_triggerMidnightMadness(request):
     import Time
+
     Time.trigger_midnight_madness()
 
 

--- a/src/common/web/index.html
+++ b/src/common/web/index.html
@@ -3,10 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/css/pico.min.css" />
     <style id="custom_styles"></style>
-    <div id="pico_css" style="display: none"></div>
-    <div id="main_css" style="display: none"></div>
-    <div id="page_css" style="display: none"></div>
     <link rel="manifest" href="/manifest.json" />
     <style>
       svg {
@@ -222,7 +220,7 @@
     <footer class="container" style="text-align: center; text-wrap: auto">
       <div class="grid">
         <section>
-          <div id="logo" aria-busy="true" width="175px"></div>
+          <img id="logo" src="/svg/logo.svg" width="175px" alt="logo" />
           <div>
             Powered by <a href="https://warpedpinball.com">Warped Pinball</a>
           </div>
@@ -231,257 +229,11 @@
       </div>
     </footer>
 
-    <div id="main_js" style="display: none"></div>
     <div id="page_js" style="display: none"></div>
-    <div id="extra_js" style="display: none"></div>
-    <div id="js-sha256" style="display: none"></div>
-    <div id="install_warning_js" style="display: none"></div>
-    <div id="configure_js" style="display: none"></div>
-
-    <script>
-      // === Configuration ===
-      const CACHE_TTL = 1000 * 60 * 10; // 10 minutes
-
-      const VERSION_KEY = "vector_version";
-      async function checkVersion() {
-        try {
-          const res = await fetch("/api/version", { cache: "no-store" });
-          if (!res.ok) return;
-          const { version } = await res.json();
-          const current = localStorage.getItem(VERSION_KEY);
-          if (current && current !== version) {
-            const savedPassword = localStorage.getItem("password");
-            localStorage.clear();
-            if (savedPassword !== null) {
-              localStorage.setItem("password", savedPassword);
-            }
-            localStorage.setItem(VERSION_KEY, version);
-            location.reload();
-          } else if (!current) {
-            localStorage.setItem(VERSION_KEY, version);
-          }
-        } catch (e) {
-          console.error("Version check failed", e);
-        }
-      }
-
-      checkVersion();
-
-      // === Utility: Cache Management ===
-      function cacheGet(url) {
-        const data = localStorage.getItem(url);
-        const time = localStorage.getItem(url + "_time");
-        if (data && time && Date.now() - parseInt(time, 10) < CACHE_TTL) {
-          return data;
-        }
-        return null;
-      }
-
-      function cacheSet(url, data) {
-        localStorage.setItem(url, data);
-        localStorage.setItem(url + "_time", Date.now().toString());
-      }
-
-      function invalidateCache(url) {
-        localStorage.removeItem(url);
-        localStorage.removeItem(url + "_time");
-      }
-
-      function clearCache() {
-        localStorage.clear();
-        location.reload();
-      }
-
-      // === Utility: Determine Resource Type ===
-      function determineResourceType(url) {
-        if (url.endsWith(".gz")) url = url.slice(0, -3);
-        const map = {
-          ".css": "css",
-          ".js": "js",
-          ".html": "html",
-          ".svg": "svg",
-          ".png": "image",
-          ".jpg": "image",
-          ".jpeg": "image",
-          ".gif": "image",
-          ".json": "json",
-        };
-        const ext = "." + url.split(".").pop();
-        return map[ext] || "unknown";
-      }
-
-      // === Utility: Authenticated Fetch ===
-      async function smartFetch(url, data = false, auth = true) {
-        console.log({ url, data, auth });
-        const headers = {
-          "Content-Type": "application/json",
-        };
-
-        if (auth) {
-          const password = await window.get_password();
-
-          const cRes = await fetch("/api/auth/challenge");
-          if (!cRes.ok) throw new Error("Failed to get challenge.");
-          const { challenge } = await cRes.json();
-
-          const urlObj = new URL(url, window.location.origin);
-
-          // stringify data if present and unescape characters
-          const data_str = data ? JSON.stringify(data) : "";
-
-          const msg = challenge + urlObj.pathname + urlObj.search + data_str;
-          const hmacHex = sha256.hmac(password, msg);
-          headers["X-Auth-HMAC"] = hmacHex;
-          headers["X-Auth-challenge"] = challenge;
-        }
-
-        const method = data ? "POST" : "GET";
-        const response = await fetch(url, {
-          method,
-          headers,
-          body: data ? JSON.stringify(data) : undefined,
-        });
-        if (auth && response.status === 401) {
-          alert("Authentication failed. Please try again.");
-          window.logout();
-        }
-        return response;
-      }
-
-      // === Utility: Fetch Resource (with optional auth) ===
-      async function fetchResource(url, timeout = 5000, auth = false) {
-        const controller = new AbortController();
-        const timer = setTimeout(() => controller.abort(), timeout);
-
-        let response;
-        if (auth) {
-          response = await smartFetch(url);
-        } else {
-          response = await fetch(url, { signal: controller.signal });
-        }
-        clearTimeout(timer);
-
-        if (!response.ok)
-          throw new Error(`Fetch error: ${response.statusText}`);
-
-        return url.endsWith(".gz") ? response.body : await response.text();
-      }
-
-      // === Utility: Decompress Data ===
-      async function decompressData(data, url) {
-        // If not gzipped or data is already a string (cached), skip decompression
-        if (!url.endsWith(".gz") || typeof data === "string") {
-          return data;
-        }
-
-        const start = performance.now();
-        const stream = data.pipeThrough(new DecompressionStream("gzip"));
-        const decompressed = await new Response(stream).text();
-        // Cache decompressed data for future loads
-        cacheSet(url, decompressed);
-        return decompressed;
-      }
-
-      // === Utility: Apply to DOM ===
-      function applyResourceToDOM(data, url, targetId) {
-        console.log(
-          `Applying data to ${targetId} from ${url} (length: ${data.length})`,
-        );
-        const placeholder = document.getElementById(targetId);
-        if (!placeholder) {
-          console.error(`Placeholder not found: ${targetId}`);
-          return;
-        }
-        const type = determineResourceType(url);
-
-        let newElement;
-        if (type === "css") {
-          newElement = document.createElement("style");
-          newElement.textContent = data;
-        } else if (type === "js") {
-          newElement = document.createElement("script");
-          newElement.src = URL.createObjectURL(
-            new Blob([data], { type: "application/javascript" }),
-          );
-          newElement.async = false;
-        } else if (type === "html") {
-          newElement = document.createElement("div");
-          newElement.innerHTML = data;
-        } else if (type === "svg") {
-          newElement = new DOMParser().parseFromString(
-            data,
-            "image/svg+xml",
-          ).documentElement;
-        } else if (type === "image") {
-          newElement = document.createElement("img");
-          newElement.src = URL.createObjectURL(
-            new Blob([data], { type: "image/png" }),
-          );
-        } else {
-          placeholder.style.display = "none";
-          return;
-        }
-
-        placeholder.replaceWith(newElement);
-        newElement.id = targetId;
-        newElement.style.display = "";
-      }
-
-      // === New Function: Fetch and Decompress (No Apply) ===
-      async function fetchDecompress(
-        url,
-        useCache = true,
-        timeout = 5000,
-        auth = false,
-      ) {
-        let data = useCache ? cacheGet(url) : null;
-        if (!data) {
-          data = await fetchResource(url, timeout, auth);
-          // Cache non-gz data immediately
-          if (!url.endsWith(".gz")) {
-            cacheSet(url, data);
-          }
-        }
-        return decompressData(data, url);
-      }
-
-      // === Main Orchestration: Fetch, Decompress, and Apply ===
-      async function fetchDecompressAndApply(
-        url,
-        targetId,
-        useCache = true,
-        timeout = 30000,
-        auth = false,
-      ) {
-        try {
-          const data = await fetchDecompress(url, useCache, timeout, auth);
-          applyResourceToDOM(data, url, targetId);
-        } catch (error) {
-          console.error(
-            `Error in fetchDecompressAndApply(${url}): ${error.message}`,
-          );
-          invalidateCache(url);
-          const placeholder = document.getElementById(targetId);
-          if (placeholder) placeholder.style.display = "none";
-        }
-      }
-
-      // Expose functions globally if needed
-      window.fetchDecompressAndApply = fetchDecompressAndApply;
-      window.fetchDecompress = fetchDecompress;
-      window.clearCache = clearCache;
-      window.smartFetch = smartFetch;
-
-      // Load default/common resources
-      fetchDecompressAndApply("/css/pico.min.css.gz", "pico_css");
-      fetchDecompressAndApply("/svg/logo.svg.gz", "logo");
-      fetchDecompressAndApply("/js/main.js.gz", "main_js");
-      fetchDecompressAndApply(
-        "/js/install_warning.js.gz",
-        "install_warning_js",
-      );
-      fetchDecompressAndApply("/js/configure.js.gz", "configure_js");
-      fetchDecompressAndApply("/js/js-sha256.min.js.gz", "js-sha256");
-    </script>
+    <script src="/js/js-sha256.min.js"></script>
+    <script src="/js/utils.js"></script>
+    <script src="/js/main.js"></script>
+    <script src="/js/install_warning.js"></script>
+    <script src="/js/configure.js"></script>
   </body>
 </html>

--- a/src/common/web/js/main.js
+++ b/src/common/web/js/main.js
@@ -5,26 +5,26 @@ const pageConfig = {
   scores: {
     title: "Scores",
     resources: [
-      { url: "/html/scores.html.gz", targetId: "page_html" },
-      { url: "/js/scores.js.gz", targetId: "page_js" },
+      { url: "/html/scores.html", targetId: "page_html" },
+      { url: "/js/scores.js", targetId: "page_js" },
     ],
   },
   about: {
     title: "About Warped Pinball",
-    resources: [{ url: "/html/about.html.gz", targetId: "page_html" }],
+    resources: [{ url: "/html/about.html", targetId: "page_html" }],
   },
   players: {
     title: "Players",
     resources: [
-      { url: "/html/players.html.gz", targetId: "page_html" },
-      { url: "/js/players.js.gz", targetId: "page_js" },
+      { url: "/html/players.html", targetId: "page_html" },
+      { url: "/js/players.js", targetId: "page_js" },
     ],
   },
   admin: {
     title: "Admin",
     resources: [
-      { url: "/html/admin.html.gz", targetId: "page_html" },
-      { url: "/js/admin.js.gz", targetId: "page_js" },
+      { url: "/html/admin.html", targetId: "page_html" },
+      { url: "/js/admin.js", targetId: "page_js" },
     ],
   },
 };
@@ -32,6 +32,29 @@ const pageConfig = {
 let previousResourceIds = [];
 let isNavigating = false;
 let currentPageKey = null;
+
+async function fetchAndApply(url, targetId) {
+  const placeholder = document.getElementById(targetId);
+  if (!placeholder) {
+    console.warn(`Target ${targetId} not found`);
+    return;
+  }
+  if (url.endsWith(".js")) {
+    const script = document.createElement("script");
+    script.src = url;
+    script.id = targetId;
+    script.async = false;
+    placeholder.replaceWith(script);
+  } else {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${url}: ${response.status}`);
+    }
+    const text = await response.text();
+    placeholder.style.display = "";
+    placeholder.innerHTML = text;
+  }
+}
 
 async function loadPageResources(pageKey) {
   const config = pageConfig[pageKey];
@@ -41,7 +64,7 @@ async function loadPageResources(pageKey) {
   }
   clearPreviousResources(previousResourceIds);
   const loadPromises = config.resources.map((resource) =>
-    fetchDecompressAndApply(resource.url, resource.targetId)
+    fetchAndApply(resource.url, resource.targetId)
       .then(() => {
         console.log(
           `Loaded resource: ${resource.url} into ${resource.targetId}`,

--- a/src/common/web/js/utils.js
+++ b/src/common/web/js/utils.js
@@ -1,0 +1,31 @@
+async function smartFetch(url, data = false, auth = true) {
+  console.log({ url, data, auth });
+  const headers = {
+    "Content-Type": "application/json",
+  };
+  if (auth) {
+    const password = await window.get_password();
+    const cRes = await fetch("/api/auth/challenge");
+    if (!cRes.ok) throw new Error("Failed to get challenge.");
+    const { challenge } = await cRes.json();
+    const urlObj = new URL(url, window.location.origin);
+    const data_str = data ? JSON.stringify(data) : "";
+    const msg = challenge + urlObj.pathname + urlObj.search + data_str;
+    const hmacHex = sha256.hmac(password, msg);
+    headers["X-Auth-HMAC"] = hmacHex;
+    headers["X-Auth-challenge"] = challenge;
+  }
+  const method = data ? "POST" : "GET";
+  const response = await fetch(url, {
+    method,
+    headers,
+    body: data ? JSON.stringify(data) : undefined,
+  });
+  if (auth && response.status === 401) {
+    alert("Authentication failed. Please try again.");
+    window.logout();
+  }
+  return response;
+}
+
+window.smartFetch = smartFetch;


### PR DESCRIPTION
## Summary
- replace custom gzip decompression with direct fetch and injection
- serve precompressed assets with `Content-Encoding: gzip`
- add shared `smartFetch` helper and compress static files
- remove committed gzip assets and let the build step gzip web resources
- skip gzipping SVG assets and set proper MIME type

## Testing
- `pre-commit run --files dev/build.py src/common/backend.py`


------
https://chatgpt.com/codex/tasks/task_e_6897af975cec83309cb8dd0007379353