### PR TITLE
Fix registry IP byte conversion in discovery

### DIFF
--- a/src/common/discovery.py
+++ b/src/common/discovery.py
@@ -235,7 +235,11 @@ def registry_ip_bytes() -> bytes:
     global known_devices, local_ip_bytes
     if not known_devices:
         return local_ip_bytes
-    return min(bytes(dev[:4]) for dev in known_devices)
+    # ``known_devices`` stores entries as strings where the first four
+    # characters are the raw IP bytes. ``bytes()`` cannot be called on a
+    # string without providing an encoding, so we convert each character to
+    # its ordinal value explicitly.
+    return min(bytes(ord(c) for c in dev[:4]) for dev in known_devices)
 
 
 def is_registry() -> bool:

--- a/tests/test_discovery_encoding.py
+++ b/tests/test_discovery_encoding.py
@@ -5,6 +5,7 @@ import sys
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
 
 from common.discovery import DiscoveryMessage, MessageType
+from common import discovery
 
 
 def _ip_chars(*bytes_):
@@ -54,3 +55,20 @@ def test_repr_full_does_not_consume():
     data = msg.encode()
     decoded = DiscoveryMessage.decode(data)
     assert list(decoded.peers) == peers
+
+
+def test_registry_ip_bytes_returns_minimum_peer_ip():
+    """Ensure registry_ip_bytes handles string entries without TypeError."""
+    # Save old globals to restore after test
+    old_devices = discovery.known_devices
+    old_local_ip = discovery.local_ip_bytes
+    try:
+        discovery.known_devices = [
+            _ip_chars(192, 168, 0, 5) + "Game5",
+            _ip_chars(192, 168, 0, 3) + "Game3",
+        ]
+        discovery.local_ip_bytes = bytes([192, 168, 0, 10])
+        assert discovery.registry_ip_bytes() == bytes([192, 168, 0, 3])
+    finally:
+        discovery.known_devices = old_devices
+        discovery.local_ip_bytes = old_local_ip


### PR DESCRIPTION
## Summary
- avoid TypeError in `registry_ip_bytes` by converting known device strings to byte values
- test `registry_ip_bytes` for correct peer IP selection

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68991bdf7c5883308dfe6689898223fa