### PR TITLE
Add EM calibration UI stubs and system feature flags

### DIFF
--- a/src/common/system_features.py
+++ b/src/common/system_features.py
@@ -1,0 +1,44 @@
+"""Helpers for exposing system-specific feature flags to the web ui."""
+
+from typing import Dict
+
+
+def get_system_features() -> Dict[str, object]:
+    """Return feature flags describing the active Vector system."""
+    features: Dict[str, object] = {
+        "vector_system": "unknown",
+        "requires_game_config": True,
+        "supports_adjustment_profiles": True,
+        "supports_on_machine_claims": True,
+        "supports_web_ui_claims": True,
+        "supports_show_ip_on_machine": True,
+        "supports_memory_snapshot": True,
+        "supports_em_calibration": False,
+        "supports_learning_process": False,
+        "max_calibration_games": 0,
+        "max_machine_name_length": 16,
+        "default_score_reels": 4,
+    }
+
+    try:
+        from systemConfig import vectorSystem  # type: ignore
+    except Exception:
+        vectorSystem = "unknown"
+
+    features["vector_system"] = vectorSystem
+
+    if vectorSystem == "em":
+        features.update(
+            {
+                "requires_game_config": False,
+                "supports_adjustment_profiles": False,
+                "supports_on_machine_claims": False,
+                "supports_show_ip_on_machine": False,
+                "supports_memory_snapshot": False,
+                "supports_em_calibration": True,
+                "supports_learning_process": True,
+                "max_calibration_games": 4,
+            }
+        )
+
+    return features

--- a/src/common/web/html/admin.html
+++ b/src/common/web/html/admin.html
@@ -97,10 +97,10 @@
       </label>
     </fieldset>
   </section>
-  <section>
+  <section id="score-claim-section">
     <h3>Score Claim Methods</h3>
     <fieldset id="score-claim-methods">
-      <label>
+      <label id="on-machine-row">
         <input
           id="on-machine-toggle"
           type="checkbox"
@@ -152,7 +152,7 @@
       </button>
     </fieldset>
   </section>
-  <section>
+  <section id="adjustments-section">
     <h3>Adjustments Profiles</h3>
     <div id="adjustments-not-supported" class="hide">
       Adjustment profiles are not yet supported for this game or rom. If you
@@ -244,7 +244,44 @@
       </div>
     </div>
   </section>
-  <section>
+  <section id="em-calibration-section" class="hide">
+    <h3>Electromechanical Calibration</h3>
+    <p>
+      <strong>Score reels:</strong>
+      <span id="em-score-reel-count">0</span>
+    </p>
+    <div class="grid">
+      <div>
+        <button id="em-capture-button">Capture Calibration Game</button>
+      </div>
+      <div>
+        <p>
+          Record a game to let Vector observe the score reel pulses while you
+          play.
+        </p>
+      </div>
+    </div>
+    <div class="grid">
+      <div>
+        <button id="em-learning-button" class="secondary" disabled>
+          Start Learning Process
+        </button>
+      </div>
+      <div>
+        <p>
+          Once you have captured calibration games, start the learning process
+          to analyse them.
+        </p>
+        <p id="em-learning-status"></p>
+      </div>
+    </div>
+    <div>
+      <h4>Calibration Games</h4>
+      <p id="em-calibration-empty">No calibration games captured yet.</p>
+      <ol id="em-calibration-list"></ol>
+    </div>
+  </section>
+  <section id="show-ip-section">
     <h3>Miscellaneous</h3>
     <fieldset>
       <label>
@@ -392,7 +429,11 @@
   </section>
   <section>
     <h3>Debug</h3>
-    <button class="secondary" onclick="downloadMemorySnapshot()">
+    <button
+      class="secondary"
+      id="download-memory-snapshot-button"
+      onclick="downloadMemorySnapshot()"
+    >
       Download Memory Snapshot
     </button>
     <button class="secondary" onclick="downloadLogs()">Download Logs</button>

--- a/src/common/web/index.html
+++ b/src/common/web/index.html
@@ -119,7 +119,7 @@
             aria-label="Pinball Admin Password"
           />
 
-          <p>
+          <p id="game-config-help">
             Please <mark>double check your game and ROM version</mark> If you
             are unsure, do not guess. If you have a ROM that is not listed we
             may be able to add it for you.
@@ -200,6 +200,30 @@
             </button>
             <button id="password_save_button">Login</button>
           </footer>
+        </article>
+      </dialog>
+      <dialog id="em-capture-progress-modal">
+        <article>
+          <h3>Capturing Calibration Game</h3>
+          <p id="em-capture-status">Preparing to capture…</p>
+          <progress id="em-capture-progress" value="0" max="100"></progress>
+          <footer>
+            <button id="em-capture-close-button" disabled>Close</button>
+          </footer>
+        </article>
+      </dialog>
+      <dialog id="em-score-entry-modal">
+        <article>
+          <h3>Enter Calibration Game Score</h3>
+          <form id="em-score-entry-form">
+            <div id="em-score-inputs" class="grid"></div>
+            <footer>
+              <button class="secondary" id="em-score-entry-cancel">
+                Cancel
+              </button>
+              <button type="submit">Save Scores</button>
+            </footer>
+          </form>
         </article>
       </dialog>
       <dialog id="confirm-modal">

--- a/src/common/web/js/utils.js
+++ b/src/common/web/js/utils.js
@@ -41,3 +41,19 @@ async function fetchGzip(url) {
 }
 
 window.fetchGzip = fetchGzip;
+
+let cachedSystemFeatures = null;
+
+async function getSystemFeatures() {
+  if (cachedSystemFeatures) {
+    return cachedSystemFeatures;
+  }
+  const response = await fetch("/api/system/features");
+  if (!response.ok) {
+    throw new Error(`Failed to fetch system features: ${response.status}`);
+  }
+  cachedSystemFeatures = await response.json();
+  return cachedSystemFeatures;
+}
+
+window.getSystemFeatures = getSystemFeatures;

--- a/src/em/backend_routes.py
+++ b/src/em/backend_routes.py
@@ -1,0 +1,106 @@
+"""Stub backend routes that are only loaded for EM builds."""
+
+from time import sleep, time
+
+from ujson import dumps as json_dumps
+
+from system_features import get_system_features
+
+_calibration_games = []
+_capture_counter = 0
+_pending_capture_id = None
+
+
+def _next_capture_id():
+    global _capture_counter
+    _capture_counter += 1
+    return f"capture-{_capture_counter}"
+
+
+def register_ap_routes(add_route):
+    """AP mode specific routes for EM systems."""
+    # No EM specific AP routes yet. This function exists to keep the
+    # registration code simple and symmetrical.
+    return
+
+
+def register_app_routes(add_route):
+    """Register EM specific application routes."""
+
+    @add_route("/api/em/status")
+    def em_status(request):
+        features = get_system_features()
+        score_reels = int(features.get("default_score_reels", 4))
+        return {
+            "score_reels": score_reels,
+            "calibration_games": list(_calibration_games),
+            "pending_capture_id": _pending_capture_id,
+            "max_games": int(features.get("max_calibration_games", 4)),
+        }
+
+    @add_route("/api/em/calibration/start_capture", auth=True)
+    def em_start_capture(request):
+        global _pending_capture_id
+        capture_id = _next_capture_id()
+        _pending_capture_id = capture_id
+
+        messages = [
+            {"progress": 0, "message": "Preparing to capture", "status": "capturing"},
+            {"progress": 25, "message": "Listening for score reel activity", "status": "capturing"},
+            {"progress": 50, "message": "Recording pulses", "status": "capturing"},
+            {"progress": 75, "message": "Wrapping up capture", "status": "capturing"},
+            {
+                "progress": 100,
+                "message": "Capture complete. Enter the final reel scores.",
+                "status": "awaiting_score",
+            },
+        ]
+
+        def generator():
+            for entry in messages:
+                payload = entry.copy()
+                payload["capture_id"] = capture_id
+                yield json_dumps(payload) + "\n"
+                sleep(1)
+
+        return generator()
+
+    @add_route("/api/em/calibration/save_game", auth=True)
+    def em_save_game(request):
+        global _pending_capture_id
+        data = request.data
+        capture_id = data.get("capture_id")
+        scores = data.get("scores", [])
+
+        if not capture_id:
+            return {"error": "Missing capture identifier"}, 400
+
+        features = get_system_features()
+        max_games = int(features.get("max_calibration_games", 4))
+
+        saved_at = int(time())
+        entry = {
+            "capture_id": capture_id,
+            "scores": scores,
+            "saved_at": saved_at,
+        }
+
+        _calibration_games.append(entry)
+        while len(_calibration_games) > max_games:
+            _calibration_games.pop(0)
+
+        if _pending_capture_id == capture_id:
+            _pending_capture_id = None
+
+        return {
+            "calibration_games": list(_calibration_games),
+            "score_reels": int(features.get("default_score_reels", 4)),
+        }
+
+    @add_route("/api/em/calibration/start_learning", auth=True)
+    def em_start_learning(request):
+        return {
+            "status": "started",
+            "games_available": len(_calibration_games),
+            "timestamp": int(time()),
+        }


### PR DESCRIPTION
## Summary
- expose system feature flags and register EM-specific backend routes, including stub calibration handlers
- allow EM builds to save a machine name instead of a game config and skip config file loading at boot
- update the configuration and admin web UIs to respect system feature flags and surface EM calibration workflows with new modals

## Testing
- python -m compileall src/common/system_features.py src/common/backend.py src/common/GameDefsLoad.py src/em/backend_routes.py src/common/web/js/configure.js src/common/web/js/admin.js

------
https://chatgpt.com/codex/tasks/task_e_68d87e5572008330a96482d18c4aaffb