### PR TITLE
Shadow Ram auto adjust for rp2040 or rp2350 in System11 and 9

### DIFF
--- a/src/sys11/Shadow_Ram_Definitions.py
+++ b/src/sys11/Shadow_Ram_Definitions.py
@@ -16,7 +16,6 @@ import uctypes
 def _is_rp2350():
     try:
         m = os.uname().machine
-        # Typical strings include "Raspberry Pi Pico 2 with RP2350"
         return ("RP2350" in m) or ("Pico 2" in m)
     except Exception:
         return False
@@ -25,7 +24,7 @@ IS_RP2350 = _is_rp2350()
 
 if IS_RP2350 == True:
   # only need 2k block
-  SRAM_DATA_BASE = 0x20081800                 #PICO2W  original 8k block
+  SRAM_DATA_BASE = 0x20081800                 #PICO2W end of ram-2k 
   SRAM_DATA_BASE_21 = SRAM_DATA_BASE >> 11    #MSBits to be preloaded in pio for address generation
   SRAM_DATA_LENGTH = 0x00000800               #2k byte total
 


### PR DESCRIPTION
## Description
Auto detect Pico1 or Pico2 and set shadow ram correctly

## Related Issues
<!--- Link to any open issues this PR addresses, e.g., Closes #123 or Resolves #456 -->

## Motivation and Context
<!--- Explain why this change is required and what problem it solves -->

## Testing
<!--- Describe your testing steps, environments, and any relevant details -->

## Screenshots (if applicable)
<!--- Add screenshots if appropriate -->

## Types of Changes
- [ ] Bug fix (non-breaking change to resolve an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] Documentation update required

## Checklist
- [ ] My code follows the project’s style guidelines.
- [ ] I have updated documentation as needed.
- [ ] I have read the CONTRIBUTING.md document.
- [ ] I have added or updated tests.
- [ ] All new and existing tests pass.

## Additional Notes
<!--- Add any extra information here -->
