### PR TITLE
skip getting time when not connected to wifi

### DIFF
--- a/src/common/backend.py
+++ b/src/common/backend.py
@@ -942,8 +942,10 @@ def add_ap_mode_routes():
 
 def connect_to_wifi(initialize=False):
     from phew import is_connected_to_wifi as phew_is_connected
+    from phew.server import initialize_timedate, schedule
 
     if phew_is_connected() and not initialize:
+        schedule(initialize_timedate, 5000, log="Server: Initialize time /date")
         return True
 
     from displayMessage import init as init_display
@@ -969,6 +971,8 @@ def connect_to_wifi(initialize=False):
             # clear any wifi related faults
             if faults.fault_is_raised(faults.ALL_WIFI):
                 faults.clear_fault(faults.ALL_WIFI)
+
+            schedule(initialize_timedate, 5000, log="Server: Initialize time & date")
 
             return True
 

--- a/src/common/phew/server.py
+++ b/src/common/phew/server.py
@@ -277,7 +277,6 @@ async def run_scheduled():
 def create_schedule(ap_mode: bool = False):
     from resource import go as resource_go
 
-    import network
     from backend import connect_to_wifi
     from discovery import broadcast_hello, listen, ping_random_peer
     from displayMessage import refresh
@@ -326,12 +325,6 @@ def create_schedule(ap_mode: bool = False):
 
         # reconnect to wifi occasionally
         schedule(connect_to_wifi, 0, 120000, log="Server: Check Wifi")
-
-        # check if we are connected to wifi
-        wlan = network.WLAN(network.STA_IF)
-        if wlan.isconnected():
-            # initialize the time and date 5 seconds after boot
-            schedule(initialize_timedate, 5000, log="Server: Initialize time /date")
 
     restart_schedule()
 


### PR DESCRIPTION
## Description
Very simple check for wifi connectivity when scheduling tasks to skip the NTP time server task when wifi is not connected so it does not hang.

## Related Issues
<!--- Link to any open issues this PR addresses, e.g., Closes #123 or Resolves #456 -->

## Motivation and Context
<!--- Explain why this change is required and what problem it solves -->

## Testing
<!--- Describe your testing steps, environments, and any relevant details -->

## Screenshots (if applicable)
<!--- Add screenshots if appropriate -->

## Types of Changes
- [ ] Bug fix (non-breaking change to resolve an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] Documentation update required

## Checklist
- [ ] My code follows the project’s style guidelines.
- [ ] I have updated documentation as needed.
- [ ] I have read the CONTRIBUTING.md document.
- [ ] I have added or updated tests.
- [ ] All new and existing tests pass.

## Additional Notes
<!--- Add any extra information here -->
