### PR TITLE
Avoid linking PR in artifact publishing commits

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -216,7 +216,7 @@ jobs:
                   repo,
                   path: repoPath,
                   branch,
-                  message: `Publish ${repoPath} for PR #${prNumber}`,
+                  message: `Publish ${repoPath} for PR ${prNumber}`,
                   content: Buffer.from(contents, 'utf8').toString('base64'),
                   sha: existingSha,
                   committer,


### PR DESCRIPTION
## Summary
- remove the `#` symbol from the pr-artifacts commit message so the workflow no longer tags the pull request conversation

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913f8fa8bf483309d1f501662f4f464)