### PR TITLE
Fix release body prep and share workflow setup

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -31,12 +31,14 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Set up Python
+      - &setup_python
+        name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
-      - name: Install dependencies (no secrets)
+      - &install_dependencies
+        name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r dev/requirements.txt
@@ -298,15 +300,9 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
+      - *setup_python
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r dev/requirements.txt
+      - *install_dependencies
 
       - name: Determine build environment and version (trusted)
         id: determine_version
@@ -355,20 +351,11 @@ jobs:
             --existing-body-file existing_body.txt \
             --output-file new_body.txt
 
-          python - <<'PY'
-            import os
-            from pathlib import Path
-
-            body = Path("new_body.txt").read_text()
-            output_path = os.environ["GITHUB_OUTPUT"]
-
-            with open(output_path, "a", encoding="utf-8") as fh:
-                fh.write("body<<EOF\n")
-                fh.write(body)
-                if not body.endswith("\n"):
-                    fh.write("\n")
-                fh.write("EOF\n")
-          PY
+          {
+            echo "body<<EOF"
+            cat new_body.txt
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create or update GitHub Release
         if: ${{ env.SHOULD_RELEASE == 'true' }}


### PR DESCRIPTION
## Summary
- fix the trusted release body preparation step so it writes to `GITHUB_OUTPUT` without triggering Python indentation errors
- reuse the Python setup and dependency installation steps across the untrusted and trusted jobs via YAML anchors to reduce duplication without exposing secrets

## Testing
- not run (workflow-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918d1650ebc8330a56679093ba293f0)