### PR TITLE
Fix reusable workflow release handling

### DIFF
--- a/.github/workflows/reusable_build_release.yml
+++ b/.github/workflows/reusable_build_release.yml
@@ -109,7 +109,6 @@ jobs:
         with:
           name: developer-updates
           path: pr-artifacts
-          artifact-content-type: raw
 
       - name: Publish raw update files
         if: ${{ inputs.include-pr-artifacts }}
@@ -312,6 +311,8 @@ jobs:
         id: prepare_body
         env:
           VERSION: ${{ env.VERSION }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           gh release view "$VERSION" --json body -q .body > existing_body.txt 2>/dev/null || true
@@ -322,10 +323,11 @@ jobs:
             --existing-body-file existing_body.txt \
             --output-file new_body.txt
 
+          delimiter="BODY_$(date +%s)"
           {
-            echo "body<<EOF"
+            echo "body<<$delimiter"
             cat new_body.txt
-            echo "EOF"
+            echo "$delimiter"
           } >> "$GITHUB_OUTPUT"
 
       - name: Create or update GitHub Release


### PR DESCRIPTION
## Summary
- ensure the release body generation step authenticates the gh CLI and writes outputs with a unique delimiter
- remove the unsupported `artifact-content-type` option from artifact uploads to align with the action's API

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918d92a02c48330b05e3aac0a9b9e78)