### PR TITLE
Handle emit-output CLI command without loading targets

### DIFF
--- a/dev/ci/workflow_helpers.py
+++ b/dev/ci/workflow_helpers.py
@@ -268,6 +268,16 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
+
+    if args.command == "emit-output":
+        emit_output(
+            args.name,
+            args.value_file.read_text(),
+            args.output_file,
+            delimiter=args.delimiter,
+        )
+        return
+
     targets = load_targets(args.targets)
 
     if args.command == "determine-version":
@@ -335,14 +345,6 @@ def main() -> None:
         )
         merged = merge_release_body(existing_body, version_section)
         args.output_file.write_text(merged)
-
-    elif args.command == "emit-output":
-        emit_output(
-            args.name,
-            args.value_file.read_text(),
-            args.output_file,
-            delimiter=args.delimiter,
-        )
 
     else:
         raise ValueError(f"Unsupported command {args.command}")

--- a/dev/tests/test_workflow_helpers.py
+++ b/dev/tests/test_workflow_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 from dev.ci import workflow_helpers as wh
@@ -112,3 +113,34 @@ def test_emit_output_respects_custom_delimiter(tmp_path: Path) -> None:
     wh.emit_output("body", "value\n", output_file, delimiter="CUSTOM")
 
     assert output_file.read_text() == "body<<CUSTOM\nvalue\nCUSTOM\n"
+
+
+def test_main_emit_output_skips_targets(monkeypatch, tmp_path: Path) -> None:
+    value_file = tmp_path / "value.txt"
+    value_file.write_text("value")
+    output_file = tmp_path / "out.txt"
+
+    def fail_load_targets(path):  # pragma: no cover - defensive
+        raise AssertionError("load_targets should not be called")
+
+    monkeypatch.setattr(wh, "load_targets", fail_load_targets)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "workflow_helpers.py",
+            "emit-output",
+            "--name",
+            "body",
+            "--value-file",
+            str(value_file),
+            "--output-file",
+            str(output_file),
+            "--delimiter",
+            "DELIM",
+        ],
+    )
+
+    wh.main()
+
+    assert output_file.read_text() == "body<<DELIM\nvalue\nDELIM\n"


### PR DESCRIPTION
## Summary
- stop loading targets for the emit-output subcommand
- add regression test to ensure emit-output runs without target parsing

## Testing
- python -m pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919275738648330af19bfca6d458a3f)