### PR TITLE
Squash dev artifact branch updates

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -144,6 +144,20 @@ jobs:
             try {
               await ensureBranch();
 
+              const { data: branchRef } = await github.rest.git.getRef({
+                owner,
+                repo,
+                ref: `heads/${branch}`,
+              });
+
+              const { data: branchCommit } = await github.rest.git.getCommit({
+                owner,
+                repo,
+                commit_sha: branchRef.object.sha,
+              });
+
+              const treeEntries = [];
+
               for (const file of files) {
                 let contents;
                 try {
@@ -158,39 +172,44 @@ jobs:
 
                 const repoPath = `${basePath}/${file.filename}`;
 
-                let existingSha;
-                try {
-                  const { data } = await github.rest.repos.getContent({
-                    owner,
-                    repo,
-                    path: repoPath,
-                    ref: branch,
-                  });
-
-                  if (!Array.isArray(data)) {
-                    existingSha = data.sha;
-                  }
-                } catch (error) {
-                  if (error.status !== 404) {
-                    throw error;
-                  }
-                }
-
-                await github.rest.repos.createOrUpdateFileContents({
-                  owner,
-                  repo,
+                treeEntries.push({
                   path: repoPath,
-                  branch,
-                  message: `Publish ${repoPath} for PR ${prNumber}`,
-                  content: Buffer.from(contents, 'utf8').toString('base64'),
-                  sha: existingSha,
-                  committer,
-                  author: committer,
+                  mode: '100644',
+                  type: 'blob',
+                  content: contents,
                 });
 
                 links.push({
                   name: file.label,
                   url: `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${repoPath}`,
+                });
+              }
+
+              if (treeEntries.length > 0) {
+                const { data: tree } = await github.rest.git.createTree({
+                  owner,
+                  repo,
+                  base_tree: branchCommit.tree.sha,
+                  tree: treeEntries,
+                });
+
+                const commitMessage = `Publish ${basePath} for PR ${prNumber}`;
+                const { data: commit } = await github.rest.git.createCommit({
+                  owner,
+                  repo,
+                  message: commitMessage,
+                  tree: tree.sha,
+                  parents: [],
+                  committer,
+                  author: committer,
+                });
+
+                await github.rest.git.updateRef({
+                  owner,
+                  repo,
+                  ref: `heads/${branch}`,
+                  sha: commit.sha,
+                  force: true,
                 });
               }
             } catch (error) {


### PR DESCRIPTION
## Description
- force PR artifact publishing to rewrite the branch as a single commit per update
- avoid long commit history while keeping all generated build files

## Related Issues
- None

## Motivation and Context
- The artifact branch accumulated many commits, cluttering the network view. Squashing keeps artifacts but trims history.

## Testing
- Not run (workflow change only)

## Screenshots (if applicable)
- N/A

## Types of Changes
- [x] Bug fix (non-breaking change to resolve an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] Documentation update required

## Checklist
- [x] My code follows the project’s style guidelines.
- [ ] I have updated documentation as needed.
- [x] I have read the CONTRIBUTING.md document.
- [ ] I have added or updated tests.
- [ ] All new and existing tests pass.

## Additional Notes
- None


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a064fa1b483308353cff9f86bcff5)