### PR TITLE
High score checksum error in build config

### DIFF
--- a/src/wpc/config/StarTrek_LX8.json
+++ b/src/wpc/config/StarTrek_LX8.json
@@ -49,9 +49,9 @@
         "NumberOfScores": 4,
         "GrandChampScoreAdr": 7306,
         "GrandChampInitAdr": 7303,
-        "ChecksumStartAdr": 7954,
+        "ChecksumStartAdr": 7922,
         "ChecksumEndAdr": 7957,
-        "ChecksumResultAdr": 7965,
+        "ChecksumResultAdr": 7958,
         "GCChecksumStartAdr": 7303,
         "GCChecksumEndAdr": 7311,
         "GCChecksumResultAdr": 7312


### PR DESCRIPTION
## Description
Star Trek LX8 showed a weakness in the auto config build process.  A valid checksum was found inside the high score space (randomly)  and so was picked.  The program now looks for the largest coverage (address space) solution.

## Related Issues
<!--- Link to any open issues this PR addresses, e.g., Closes #123 or Resolves #456 -->

## Motivation and Context
<!--- Explain why this change is required and what problem it solves -->

## Testing
<!--- Describe your testing steps, environments, and any relevant details -->

## Screenshots (if applicable)
<!--- Add screenshots if appropriate -->

## Types of Changes
- [ ] Bug fix (non-breaking change to resolve an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] Documentation update required

## Checklist
- [ ] My code follows the project’s style guidelines.
- [ ] I have updated documentation as needed.
- [ ] I have read the CONTRIBUTING.md document.
- [ ] I have added or updated tests.
- [ ] All new and existing tests pass.

## Additional Notes
<!--- Add any extra information here -->
