### PR TITLE
Simplify docs layouts and navigation

### DIFF
--- a/docs/authentication.html
+++ b/docs/authentication.html
@@ -4,37 +4,40 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Vector HTTP API Authentication</title>
-  <style>
-    body { font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif; max-width: 960px; margin: 2.5rem auto; padding: 0 1.5rem 3rem; color: #e5e7eb; background: #0d1117; }
-    h1, h2, h3 { color: #e5e7eb; }
-    a { color: #38bdf8; text-decoration: none; }
-    a:hover { text-decoration: underline; }
-    code { background: #0b1221; color: #f8fafc; padding: 2px 6px; border-radius: 6px; border: 1px solid #1d2a3f; }
-    pre { background: #0b1221; color: #f8fafc; padding: 1rem; border-radius: 12px; border: 1px solid #1d2a3f; overflow-x: auto; }
-    pre code { display: block; font-family: 'Fira Code', 'SFMono-Regular', Consolas, monospace; line-height: 1.5; border: none; background: transparent; padding: 0; }
-    .panel { background: #111827; border: 1px solid #1f2937; border-radius: 14px; padding: 1.5rem; box-shadow: 0 10px 30px rgba(0,0,0,0.35); margin-bottom: 1.75rem; }
-    ol { padding-left: 1.25rem; }
-  </style>
+    <style>
+      body { font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif; max-width: 960px; margin: 2.5rem auto; padding: 0 1.5rem 3rem; color: #e5e7eb; background: #0d1117; line-height: 1.6; }
+      h1, h2, h3 { color: #e5e7eb; margin-bottom: 0.35rem; }
+      a { color: #38bdf8; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      code { background: #0b1221; color: #f8fafc; padding: 2px 6px; border-radius: 6px; border: 1px solid #1d2a3f; }
+      pre { background: #0b1221; color: #f8fafc; padding: 1rem; border-radius: 12px; border: 1px solid #1d2a3f; overflow-x: auto; }
+      pre code { display: block; font-family: 'Fira Code', 'SFMono-Regular', Consolas, monospace; line-height: 1.5; border: none; background: transparent; padding: 0; white-space: pre; }
+      main { display: flex; flex-direction: column; gap: 1.5rem; }
+      section { padding-bottom: 1rem; border-bottom: 1px solid #1f2937; }
+      section:last-of-type { border-bottom: none; }
+      ol { padding-left: 1.25rem; }
+    </style>
 </head>
-<body>
-  <h1>Network access and authentication</h1>
-  <div class="panel">
-    <p>Every Vector HTTP route is served over standard HTTP using POST requests. Point your client at the board's IP address (for example <code>http://192.168.4.243</code>) and include a JSON payload when the route expects a body.</p>
-    <p>Routes marked as authenticated require an HMAC signature tied to a one-time challenge token. Use the flow below whenever authentication is required.</p>
-  </div>
-  <div class="panel">
-    <h2>Authentication flow</h2>
-    <ol>
-      <li>Call <code>/api/auth/challenge</code> with POST to receive a hexadecimal <code>challenge</code> string.</li>
-      <li>Build the message string by concatenating <code>challenge + request_path + raw_body</code>. If the request has no body, use an empty string for <code>raw_body</code>.</li>
-      <li>Compute the HMAC-SHA256 digest of the message using the configured password as the key.</li>
-      <li>Send the protected POST request with headers <code>x-auth-challenge</code> (the issued token) and <code>x-auth-hmac</code> (the hexadecimal digest).</li>
-      <li>Challenges expire after 60 seconds and are removed once successfully used. Request a new challenge if you receive an expiration or invalid challenge error.</li>
-    </ol>
-  </div>
-  <div class="panel">
-    <h2>Ready-to-run Python example</h2>
-    <p>This script retrieves a challenge, signs a protected request, and prints the response using POST-only API calls.</p>
+  <body>
+    <main>
+      <header>
+        <h1>Network access and authentication</h1>
+        <p>Every Vector HTTP route is served over standard HTTP using POST requests. Point your client at the board's IP address (for example <code>http://192.168.4.243</code>) and include a JSON payload when the route expects a body.</p>
+        <p>Routes marked as authenticated require an HMAC signature tied to a one-time challenge token. Use the flow below whenever authentication is required.</p>
+      </header>
+      <section>
+        <h2>Authentication flow</h2>
+        <ol>
+          <li>Call <code>/api/auth/challenge</code> with POST to receive a hexadecimal <code>challenge</code> string.</li>
+          <li>Build the message string by concatenating <code>challenge + request_path + raw_body</code>. If the request has no body, use an empty string for <code>raw_body</code>.</li>
+          <li>Compute the HMAC-SHA256 digest of the message using the configured password as the key.</li>
+          <li>Send the protected POST request with headers <code>x-auth-challenge</code> (the issued token) and <code>x-auth-hmac</code> (the hexadecimal digest).</li>
+          <li>Challenges expire after 60 seconds and are removed once successfully used. Request a new challenge if you receive an expiration or invalid challenge error.</li>
+        </ol>
+      </section>
+      <section>
+        <h2>Ready-to-run Python example</h2>
+        <p>This script retrieves a challenge, signs a protected request, and prints the response using POST-only API calls.</p>
 <pre><code>import hashlib
 import hmac
 import json
@@ -71,8 +74,9 @@ resp = requests.post(
 )
 print("show_ip response:", resp.text)
 </code></pre>
-    <p>Swap <code>BASE_URL</code> and <code>PASSWORD</code> for your device. Always serialize the JSON body exactly as sent to the server when computing the signature.</p>
-  </div>
-  <p><a href="index.html">Back to API reference</a></p>
-</body>
+        <p>Swap <code>BASE_URL</code> and <code>PASSWORD</code> for your device. Always serialize the JSON body exactly as sent to the server when computing the signature.</p>
+      </section>
+      <p><a href="index.html">Back to API reference</a></p>
+    </main>
+  </body>
 </html>

--- a/docs/discovery.html
+++ b/docs/discovery.html
@@ -6,14 +6,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Discover boards on the network</title>
   <style>
-    body { font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif; max-width: 960px; margin: 2.5rem auto; padding: 0 1.5rem 3rem; color: #e5e7eb; background: #0d1117; }
-    h1, h2, h3 { color: #e5e7eb; }
+      body { font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif; max-width: 960px; margin: 2.5rem auto; padding: 0 1.5rem 3rem; color: #e5e7eb; background: #0d1117; line-height: 1.6; }
+      h1, h2, h3 { color: #e5e7eb; }
     a { color: #38bdf8; text-decoration: none; }
     a:hover { text-decoration: underline; }
     code { background: #0b1221; color: #f8fafc; padding: 2px 6px; border-radius: 6px; border: 1px solid #1d2a3f; }
-    pre { background: #0b1221; color: #f8fafc; padding: 1rem; border-radius: 12px; border: 1px solid #1d2a3f; overflow-x: auto; }
-    pre code { display: block; font-family: 'Fira Code', 'SFMono-Regular', Consolas, monospace; line-height: 1.5; border: none; background: transparent; padding: 0; }
-    .panel { background: #111827; border: 1px solid #1f2937; border-radius: 14px; padding: 1.5rem; box-shadow: 0 10px 30px rgba(0,0,0,0.35); margin-bottom: 1.75rem; }
+      pre { background: #0b1221; color: #f8fafc; padding: 1rem; border-radius: 12px; border: 1px solid #1d2a3f; overflow-x: auto; }
+      pre code { display: block; font-family: 'Fira Code', 'SFMono-Regular', Consolas, monospace; line-height: 1.5; border: none; background: transparent; padding: 0; white-space: pre; }
+      .panel { background: none; border: none; border-bottom: 1px solid #1f2937; border-radius: 0; padding: 0 0 1.25rem; box-shadow: none; margin-bottom: 1.5rem; }
     ol { padding-left: 1.25rem; }
   </style>
 </head>

--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -7,23 +7,12 @@
   <link rel="stylesheet" href="./style.css">
 </head>
 <body>
-  <header class="topbar">
-    <div class="nav">
-      <strong>Vector Guides</strong>
-      <div class="links">
-        <a class="pill" href="../index.html">API home</a>
-        <a class="pill" href="#start">Start here</a>
-        <a class="pill" href="#systems">Systems</a>
-        <a class="pill" href="#resources">Resources</a>
-      </div>
-    </div>
-  </header>
-
   <main>
     <div class="panel hero">
       <div>
         <h1>Warped Pinball Vector</h1>
         <p class="meta">Connectivity, diagnostics, and modern tooling for classic pinball systems. These guides replace the old wiki and collect quick starts, full manuals, and ROM management notes in one place.</p>
+        <p class="meta">If you need the HTTP API reference, jump back to the <a href="../index.html">main docs</a>. Otherwise, pick a system below to dive into the guides.</p>
         <div class="badge">
           <a class="pill" href="#systems">Browse by system</a>
           <a class="pill" href="https://youtube.com/playlist?list=PLviUqcd3jBxrLbbLz9X2bv3VnlM3TLe6F&si=zwGBoLwztZszCIlE" target="_blank" rel="noopener noreferrer">Installation videos</a>

--- a/docs/guides/style.css
+++ b/docs/guides/style.css
@@ -21,22 +21,11 @@ body {
   background: radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.08), transparent 25%),
               radial-gradient(circle at 80% 0%, rgba(14, 165, 233, 0.08), transparent 25%),
               var(--bg);
+  line-height: 1.6;
 }
 h1, h2, h3, h4 { color: var(--text); }
 a { color: var(--accent); text-decoration: none; }
 a:hover { text-decoration: underline; }
-.topbar {
-  position: sticky;
-  top: 0;
-  backdrop-filter: blur(12px);
-  background: rgba(13,17,23,0.9);
-  border-bottom: 1px solid var(--panel-border);
-  padding: 1rem 0;
-  margin-bottom: 1rem;
-  z-index: 20;
-}
-.nav { display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center; }
-.nav .links { display: flex; flex-wrap: wrap; gap: 0.5rem; }
 .pill {
   display: inline-flex;
   align-items: center;
@@ -50,21 +39,22 @@ a:hover { text-decoration: underline; }
   box-shadow: var(--shadow);
 }
 .panel {
-  background: var(--panel);
-  border: 1px solid var(--panel-border);
-  border-radius: 14px;
-  padding: 1.5rem;
-  box-shadow: var(--shadow);
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--panel-border);
+  border-radius: 0;
+  padding: 0 0 1.25rem;
+  box-shadow: none;
   margin-bottom: 1.5rem;
 }
 .meta { color: var(--muted); font-size: 0.95rem; margin: 0.5rem 0 1rem; }
-.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; }
+.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1.25rem; }
 .card {
-  padding: 1rem;
-  border-radius: 12px;
+  padding: 0.5rem 0.75rem;
+  border-radius: 10px;
   border: 1px solid var(--panel-border);
-  background: rgba(255,255,255,0.02);
-  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.02);
+  background: none;
+  box-shadow: none;
 }
 .card h3 { margin-top: 0; }
 .toc { list-style: none; padding-left: 0; }

--- a/docs/guides/system11/add-rom.html
+++ b/docs/guides/system11/add-rom.html
@@ -7,21 +7,11 @@
   <link rel="stylesheet" href="../style.css">
 </head>
 <body>
-  <header class="topbar">
-    <div class="nav">
-      <strong>System 9/11 ROM Profile</strong>
-      <div class="links">
-        <a class="pill" href="../index.html">All guides</a>
-        <a class="pill" href="#process">Process</a>
-        <a class="pill" href="#checklist">File checklist</a>
-      </div>
-    </div>
-  </header>
-
   <main>
     <div class="panel hero">
       <div>
         <h1>System 9 &amp; 11 WiFi App Note: New Game ROM Profile</h1>
+        <p class=\"meta\">Back to <a href=\"../index.html\">all guides</a>.</p>
         <p class="meta">Collect the data needed to add support for new System 9 or 11 titles.</p>
         <a class="btn" href="https://raw.githubusercontent.com/wiki/warped-pinball/vector/wiki-pdf/System%2011/System%2011%20Add%20a%20Rom.pdf">Download as PDF</a>
       </div>

--- a/docs/guides/system11/manual.html
+++ b/docs/guides/system11/manual.html
@@ -7,20 +7,11 @@
   <link rel="stylesheet" href="../style.css">
 </head>
 <body>
-  <header class="topbar">
-    <div class="nav">
-      <strong>System 11 Manual</strong>
-      <div class="links">
-        <a class="pill" href="../index.html">All guides</a>
-        <a class="pill" href="#toc">Contents</a>
-      </div>
-    </div>
-  </header>
-
   <main>
     <div class="panel hero">
       <div>
         <h1>System 11 WiFi Module Installation and Use Manual</h1>
+        <p class=\"meta\">Back to <a href=\"../index.html\">all guides</a>.</p>
         <p class="meta">Indicators, installation steps, WiFi setup, and operational notes for SYS11.WiFi.</p>
         <a class="btn" href="https://raw.githubusercontent.com/wiki/warped-pinball/vector/wiki-pdf/System%2011/System%2011%20Manual.pdf">Download as PDF</a>
       </div>

--- a/docs/guides/system11/quick-start.html
+++ b/docs/guides/system11/quick-start.html
@@ -7,20 +7,11 @@
   <link rel="stylesheet" href="../style.css">
 </head>
 <body>
-  <header class="topbar">
-    <div class="nav">
-      <strong>System 11 Quick Start</strong>
-      <div class="links">
-        <a class="pill" href="../index.html">All guides</a>
-        <a class="pill" href="#steps">Install steps</a>
-      </div>
-    </div>
-  </header>
-
   <main>
     <div class="panel hero">
       <div>
         <h1>System 11 WiFi Quick Start (v1.1)</h1>
+        <p class=\"meta\">Back to <a href=\"../index.html\">all guides</a>.</p>
         <p class="meta">Fast-path instructions for installing the Warped Pinball System 11 WiFi board.</p>
         <a class="btn" href="https://raw.githubusercontent.com/wiki/warped-pinball/vector/wiki-pdf/System%2011/System%2011%20Quick%20Start.pdf">Download as PDF</a>
       </div>

--- a/docs/guides/system9/manual.html
+++ b/docs/guides/system9/manual.html
@@ -7,20 +7,11 @@
   <link rel="stylesheet" href="../style.css">
 </head>
 <body>
-  <header class="topbar">
-    <div class="nav">
-      <strong>System 9 Manual</strong>
-      <div class="links">
-        <a class="pill" href="../index.html">All guides</a>
-        <a class="pill" href="#toc">Contents</a>
-      </div>
-    </div>
-  </header>
-
   <main>
     <div class="panel hero">
       <div>
         <h1>System 9 WiFi Module Installation and Use Manual</h1>
+        <p class=\"meta\">Back to <a href=\"../index.html\">all guides</a>.</p>
         <p class="meta">Setup and operation details for SYS9.WiFi.</p>
         <a class="btn" href="https://raw.githubusercontent.com/wiki/warped-pinball/vector/wiki-pdf/System%209/System%209%20Manual.pdf">Download as PDF</a>
       </div>

--- a/docs/guides/wpc/add-rom.html
+++ b/docs/guides/wpc/add-rom.html
@@ -7,20 +7,11 @@
   <link rel="stylesheet" href="../style.css">
 </head>
 <body>
-  <header class="topbar">
-    <div class="nav">
-      <strong>WPC ROM Profile</strong>
-      <div class="links">
-        <a class="pill" href="../index.html">All guides</a>
-        <a class="pill" href="#process">Process</a>
-      </div>
-    </div>
-  </header>
-
   <main>
     <div class="panel hero">
       <div>
         <h1>WPC WiFi App Note: New Game ROM Profile</h1>
+        <p class=\"meta\">Back to <a href=\"../index.html\">all guides</a>.</p>
         <p class="meta">Collect memory images so a new WPC title can be profiled for scoring and leaderboard support.</p>
         <a class="btn" href="https://raw.githubusercontent.com/wiki/warped-pinball/vector/wiki-pdf/WPC/WPC%20Add%20a%20Rom.pdf">Download as PDF</a>
       </div>

--- a/docs/guides/wpc/manual.html
+++ b/docs/guides/wpc/manual.html
@@ -7,22 +7,11 @@
   <link rel="stylesheet" href="../style.css">
 </head>
 <body>
-  <header class="topbar">
-    <div class="nav">
-      <strong>WPC Manual</strong>
-      <div class="links">
-        <a class="pill" href="../index.html">All guides</a>
-        <a class="pill" href="#toc">Contents</a>
-        <a class="pill" href="#hardware">Install</a>
-        <a class="pill" href="#wifi">WiFi setup</a>
-      </div>
-    </div>
-  </header>
-
   <main>
     <div class="panel hero">
       <div>
         <h1>System WPC WiFi Module Installation and Use Manual</h1>
+        <p class=\"meta\">Back to <a href=\"../index.html\">all guides</a>.</p>
         <p class="meta">How the SYSWPC.WiFi board installs, what the LEDs mean, and how to bring a classic Williams/Bally WPC machine online.</p>
         <a class="btn" href="https://raw.githubusercontent.com/wiki/warped-pinball/vector/wiki-pdf/WPC/WPC%20Manual.pdf">Download as PDF</a>
       </div>

--- a/docs/guides/wpc/quick-start.html
+++ b/docs/guides/wpc/quick-start.html
@@ -7,21 +7,11 @@
   <link rel="stylesheet" href="../style.css">
 </head>
 <body>
-  <header class="topbar">
-    <div class="nav">
-      <strong>WPC Quick Start</strong>
-      <div class="links">
-        <a class="pill" href="../index.html">All guides</a>
-        <a class="pill" href="#overview">Overview</a>
-        <a class="pill" href="#supported">Supported titles</a>
-      </div>
-    </div>
-  </header>
-
   <main>
     <div class="panel hero">
       <div>
         <h1>System WPC WiFi Module Quick Start Guide</h1>
+        <p class=\"meta\">Back to <a href=\"../index.html\">all guides</a>.</p>
         <p class="meta">Fast install steps plus LED references for Williams/Bally WPC boards.</p>
         <a class="btn" href="https://raw.githubusercontent.com/wiki/warped-pinball/vector/wiki-pdf/WPC/WPC%20Quick%20Start.pdf">Download as PDF</a>
       </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -43,20 +43,6 @@
     ul { list-style: none; padding-left: 0; }
     ul li { margin: 0.35rem 0; }
     .meta { color: var(--muted); font-size: 0.95rem; margin: 0.35rem 0; }
-    .topbar {
-      position: sticky;
-      top: 0;
-      backdrop-filter: blur(12px);
-      background: linear-gradient(90deg, rgba(13,17,23,0.95), rgba(13,17,23,0.85));
-      border-bottom: 1px solid var(--panel-border);
-      padding: 0.75rem 0;
-      margin-bottom: 1.5rem;
-      z-index: 20;
-    }
-    .topbar .nav { display: flex; flex-wrap: wrap; gap: 1rem; align-items: center; justify-content: space-between; }
-    .brand { display: flex; align-items: center; gap: 0.6rem; font-weight: 700; font-size: 1.05rem; }
-    .brand span { padding: 0.3rem 0.75rem; border-radius: 10px; border: 1px solid var(--panel-border); background: rgba(255,255,255,0.03); box-shadow: var(--shadow); }
-    .topbar .nav-links { display: flex; flex-wrap: wrap; gap: 0.35rem; align-items: center; }
     .nav-link { padding: 0.45rem 0.85rem; border-radius: 10px; border: 1px solid transparent; font-weight: 600; color: var(--text); }
     .nav-link:hover { border-color: var(--panel-border); background: rgba(56,189,248,0.08); text-decoration: none; }
     .badge { display: flex; flex-wrap: wrap; gap: 0.6rem; align-items: center; }
@@ -69,20 +55,6 @@
 </head>
 <body>
   <a id="top"></a>
-  <header class="topbar">
-    <div class="nav">
-      <div class="brand">
-        <span>Vector documentation</span>
-        <a class="nav-link" href="https://github.com/warped-pinball/vector" target="_blank" rel="noopener noreferrer">Main repository</a>
-        <a class="nav-link" href="https://vector.doze.dev" target="_blank" rel="noopener noreferrer">Live demo</a>
-      </div>
-      <div class="nav-links">
-        <a class="nav-link" href="#owners">Owner's guides</a>
-        <a class="nav-link" href="#technical">Mod maker &amp; technical guides</a>
-        <a class="nav-link" href="#top">Back to top</a>
-      </div>
-    </div>
-  </header>
   <main>
     <div class="panel hero">
       <div>
@@ -92,6 +64,8 @@
       <div class="badge">
         <a class="nav-link" href="#owners">Browse owner guides</a>
         <a class="nav-link" href="#technical">Open technical docs</a>
+        <a class="nav-link" href="https://github.com/warped-pinball/vector" target="_blank" rel="noopener noreferrer">Main repository</a>
+        <a class="nav-link" href="https://vector.doze.dev" target="_blank" rel="noopener noreferrer">Live demo</a>
         <a class="nav-link" href="https://github.com/warped-pinball/vector/releases/latest" target="_blank" rel="noopener noreferrer">Latest release</a>
       </div>
     </div>

--- a/docs/routes.html
+++ b/docs/routes.html
@@ -58,18 +58,6 @@
     pre code { display: block; font-family: 'Fira Code', 'SFMono-Regular', Consolas, monospace; font-size: 0.95rem; line-height: 1.5; border: none; background: transparent; padding: 0; }
     .meta { color: var(--muted); font-size: 0.95rem; margin: 0.35rem 0; }
     .tag { display: inline-block; padding: 0.2rem 0.6rem; border-radius: 999px; font-size: 0.85rem; border: 1px solid var(--panel-border); background: rgba(56,189,248,0.1); color: var(--accent); }
-    .topbar {
-      position: sticky;
-      top: 0;
-      backdrop-filter: blur(12px);
-      background: rgba(13,17,23,0.9);
-      border-bottom: 1px solid var(--panel-border);
-      padding: 1rem 0;
-      margin-bottom: 1rem;
-      z-index: 20;
-    }
-    .topbar .nav { display: flex; flex-wrap: wrap; gap: 0.65rem; align-items: center; justify-content: space-between; }
-    .topbar .nav-links { display: flex; flex-wrap: wrap; gap: 0.65rem; align-items: center; }
     .pill {
       display: inline-flex;
       align-items: center;
@@ -92,38 +80,25 @@
     .toc-list li { margin: 0.25rem 0; }
     .spacer { flex: 1 1 auto; }
     .back-top { text-align: right; margin-top: 1rem; }
+    pre code { white-space: pre; }
   </style>
 </head>
 <body>
   <a id="top"></a>
-  <header class="topbar">
-    <div class="nav">
-      <div class="badge">
-        <strong>Vector API Routes</strong>
-        <a class="pill" href="index.html">Docs home</a>
-        <a class="pill" href="https://github.com/warped-pinball/vector/releases/latest" target="_blank" rel="noopener noreferrer">Release badge</a>
-        <img alt="Latest release" src="https://img.shields.io/github/v/release/warped-pinball/vector?label=release" />
-        <img alt="Last commit" src="https://img.shields.io/github/last-commit/warped-pinball/vector?label=updated" />
-      </div>
-      <div class="nav-links">
-        <a class="pill" href="https://github.com/warped-pinball/vector" target="_blank" rel="noopener noreferrer">Main repository</a>
-        <a class="pill" href="https://warpedpinball.com" target="_blank" rel="noopener noreferrer">WarpedPinball.com</a>
-        <a class="pill" href="https://vector.doze.dev" target="_blank" rel="noopener noreferrer">Live demo</a>
-        <a class="pill" href="#top">Back to top</a>
-      </div>
-    </div>
-  </header>
   <main>
     <div class="panel hero">
       <div>
         <h1>Vector HTTP API</h1>
         <p class="meta">Generated automatically from <code>src/common/backend.py</code>. This page is dedicated to the route and endpoint documentation for the Vector API.</p>
       </div>
-      <div class="meta">
+      <div class="badge">
         <span class="tag">Statically generated</span>
         <span class="tag">MicroPython friendly</span>
+        <a class="pill" href="authentication.html">Authentication guide</a>
+        <a class="pill" href="index.html">Docs home</a>
+        <a class="pill" href="https://github.com/warped-pinball/vector" target="_blank" rel="noopener noreferrer">Repository</a>
+        <a class="pill" href="https://vector.doze.dev" target="_blank" rel="noopener noreferrer">Live demo</a>
       </div>
-      <p class="meta">Need authentication details? Visit the <a href="authentication.html">Authentication guide</a>.</p>
     </div>
 
     <div class="panel" id="routes">
@@ -204,16 +179,15 @@
       <h3>Request</h3>
       <p>No parameters inferred.</p>
       <h3>Response</h3>
-      <h4>Status Codes</h4><ul><li><code>200</code> - Configurations listed</li></ul><p><strong>Response body:</strong> Mapping of configuration filenames to human-readable titles</p><pre><code>{&quot;F14_L1&quot;: {&quot;name&quot;: &quot;F14 Tomcat&quot;, &quot;rom&quot;: &quot;L1&quot;}, &quot;Taxi_L4&quot;: {&quot;name&quot;: &quot;Taxi&quot;, &quot;rom&quot;: &quot;L4&quot;}}
-{
-&quot;F14_L1&quot;: {
-&quot;name&quot;: &quot;F14 Tomcat&quot;,
-&quot;rom&quot;: &quot;L1&quot;
-},
-&quot;Taxi_L4&quot;: {
-&quot;name&quot;: &quot;Taxi&quot;,
-&quot;rom&quot;: &quot;L4&quot;
-}
+      <h4>Status Codes</h4><ul><li><code>200</code> - Configurations listed</li></ul><p><strong>Response body:</strong> Mapping of configuration filenames to human-readable titles</p><pre><code>{
+  "F14_L1": {
+    "name": "F14 Tomcat",
+    "rom": "L1"
+  },
+  "Taxi_L4": {
+    "name": "Taxi",
+    "rom": "L4"
+  }
 }</code></pre>
     </section>
     
@@ -613,11 +587,11 @@
       <p>No parameters inferred.</p>
       <h3>Response</h3>
       <h4>Status Codes</h4><ul><li><code>200</code> - Networks listed</li></ul><p><strong>Response body:</strong> Array of SSID records with signal quality and configuration flag</p><pre><code>[
-{
-&quot;ssid&quot;: &quot;MyNetwork&quot;,
-&quot;rssi&quot;: -40,
-&quot;configured&quot;: true
-}
+  {
+    "ssid": "MyNetwork",
+    "rssi": -40,
+    "configured": true
+  }
 ]</code></pre>
     </section>
     

--- a/docs/usb.html
+++ b/docs/usb.html
@@ -17,6 +17,7 @@
         padding: 0 1.5rem 3rem;
         color: #e5e7eb;
         background: #0d1117;
+        line-height: 1.6;
       }
       h1,
       h2,
@@ -52,14 +53,16 @@
         border: none;
         background: transparent;
         padding: 0;
+        white-space: pre;
       }
       .panel {
-        background: #111827;
-        border: 1px solid #1f2937;
-        border-radius: 14px;
-        padding: 1.5rem;
-        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
-        margin-bottom: 1.75rem;
+        background: none;
+        border: none;
+        border-bottom: 1px solid #1f2937;
+        border-radius: 0;
+        padding: 0 0 1.25rem;
+        box-shadow: none;
+        margin-bottom: 1.5rem;
       }
       ol {
         padding-left: 1.25rem;


### PR DESCRIPTION
## Summary
- remove top navigation bars across docs and fold those links into page content
- simplify page styling to feel more like readable markdown for guides and technical docs
- fix API example formatting, including proper indentation for code samples

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c7243edbc83309247d26c938053ad)