### PR TITLE
Add print-based PDF download option to guides

### DIFF
--- a/docs/guides/print.js
+++ b/docs/guides/print.js
@@ -1,0 +1,16 @@
+(function() {
+  function attachPrintHandlers() {
+    const buttons = document.querySelectorAll('[data-print-pdf]');
+    buttons.forEach((button) => {
+      button.addEventListener('click', () => {
+        window.print();
+      });
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', attachPrintHandlers);
+  } else {
+    attachPrintHandlers();
+  }
+})();

--- a/docs/guides/style.css
+++ b/docs/guides/style.css
@@ -104,3 +104,9 @@ th { background: rgba(56,189,248,0.08); }
 }
 .btn:hover { text-decoration: none; border-color: var(--accent); }
 .anchor { color: inherit; }
+
+@media print {
+  .print-hidden {
+    display: none !important;
+  }
+}

--- a/docs/guides/system11/add-rom.html
+++ b/docs/guides/system11/add-rom.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>System 9 &amp; 11 ROM Profile</title>
   <link rel="stylesheet" href="../style.css">
+  <script defer src="../print.js"></script>
 </head>
 <body>
   <main>
@@ -13,7 +14,7 @@
         <h1>System 9 &amp; 11 WiFi App Note: New Game ROM Profile</h1>
         <p class=\"meta\">Back to <a href=\"../index.html\">all guides</a>.</p>
         <p class="meta">Collect the data needed to add support for new System 9 or 11 titles.</p>
-        <a class="btn" href="https://raw.githubusercontent.com/wiki/warped-pinball/vector/wiki-pdf/System%2011/System%2011%20Add%20a%20Rom.pdf">Download as PDF</a>
+        <button type="button" class="btn print-hidden" data-print-pdf>Download as PDF</button>
       </div>
     </div>
 

--- a/docs/guides/system11/manual.html
+++ b/docs/guides/system11/manual.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>System 11 Installation & Use Manual</title>
   <link rel="stylesheet" href="../style.css">
+  <script defer src="../print.js"></script>
 </head>
 <body>
   <main>
@@ -13,7 +14,7 @@
         <h1>System 11 WiFi Module Installation and Use Manual</h1>
         <p class=\"meta\">Back to <a href=\"../index.html\">all guides</a>.</p>
         <p class="meta">Indicators, installation steps, WiFi setup, and operational notes for SYS11.WiFi.</p>
-        <a class="btn" href="https://raw.githubusercontent.com/wiki/warped-pinball/vector/wiki-pdf/System%2011/System%2011%20Manual.pdf">Download as PDF</a>
+        <button type="button" class="btn print-hidden" data-print-pdf>Download as PDF</button>
       </div>
     </div>
 

--- a/docs/guides/system11/quick-start.html
+++ b/docs/guides/system11/quick-start.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>System 11 Quick Start</title>
   <link rel="stylesheet" href="../style.css">
+  <script defer src="../print.js"></script>
 </head>
 <body>
   <main>
@@ -13,7 +14,7 @@
         <h1>System 11 WiFi Quick Start (v1.1)</h1>
         <p class=\"meta\">Back to <a href=\"../index.html\">all guides</a>.</p>
         <p class="meta">Fast-path instructions for installing the Warped Pinball System 11 WiFi board.</p>
-        <a class="btn" href="https://raw.githubusercontent.com/wiki/warped-pinball/vector/wiki-pdf/System%2011/System%2011%20Quick%20Start.pdf">Download as PDF</a>
+        <button type="button" class="btn print-hidden" data-print-pdf>Download as PDF</button>
       </div>
     </div>
 

--- a/docs/guides/system9/manual.html
+++ b/docs/guides/system9/manual.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>System 9 Installation & Use Manual</title>
   <link rel="stylesheet" href="../style.css">
+  <script defer src="../print.js"></script>
 </head>
 <body>
   <main>
@@ -13,7 +14,7 @@
         <h1>System 9 WiFi Module Installation and Use Manual</h1>
         <p class=\"meta\">Back to <a href=\"../index.html\">all guides</a>.</p>
         <p class="meta">Setup and operation details for SYS9.WiFi.</p>
-        <a class="btn" href="https://raw.githubusercontent.com/wiki/warped-pinball/vector/wiki-pdf/System%209/System%209%20Manual.pdf">Download as PDF</a>
+        <button type="button" class="btn print-hidden" data-print-pdf>Download as PDF</button>
       </div>
     </div>
 

--- a/docs/guides/wpc/add-rom.html
+++ b/docs/guides/wpc/add-rom.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>WPC Add a ROM Profile</title>
   <link rel="stylesheet" href="../style.css">
+  <script defer src="../print.js"></script>
 </head>
 <body>
   <main>
@@ -13,7 +14,7 @@
         <h1>WPC WiFi App Note: New Game ROM Profile</h1>
         <p class=\"meta\">Back to <a href=\"../index.html\">all guides</a>.</p>
         <p class="meta">Collect memory images so a new WPC title can be profiled for scoring and leaderboard support.</p>
-        <a class="btn" href="https://raw.githubusercontent.com/wiki/warped-pinball/vector/wiki-pdf/WPC/WPC%20Add%20a%20Rom.pdf">Download as PDF</a>
+        <button type="button" class="btn print-hidden" data-print-pdf>Download as PDF</button>
       </div>
     </div>
 

--- a/docs/guides/wpc/manual.html
+++ b/docs/guides/wpc/manual.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>WPC Installation & Use Manual</title>
   <link rel="stylesheet" href="../style.css">
+  <script defer src="../print.js"></script>
 </head>
 <body>
   <main>
@@ -13,7 +14,7 @@
         <h1>System WPC WiFi Module Installation and Use Manual</h1>
         <p class=\"meta\">Back to <a href=\"../index.html\">all guides</a>.</p>
         <p class="meta">How the SYSWPC.WiFi board installs, what the LEDs mean, and how to bring a classic Williams/Bally WPC machine online.</p>
-        <a class="btn" href="https://raw.githubusercontent.com/wiki/warped-pinball/vector/wiki-pdf/WPC/WPC%20Manual.pdf">Download as PDF</a>
+        <button type="button" class="btn print-hidden" data-print-pdf>Download as PDF</button>
       </div>
     </div>
 

--- a/docs/guides/wpc/quick-start.html
+++ b/docs/guides/wpc/quick-start.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>WPC Quick Start</title>
   <link rel="stylesheet" href="../style.css">
+  <script defer src="../print.js"></script>
 </head>
 <body>
   <main>
@@ -13,7 +14,7 @@
         <h1>System WPC WiFi Module Quick Start Guide</h1>
         <p class=\"meta\">Back to <a href=\"../index.html\">all guides</a>.</p>
         <p class="meta">Fast install steps plus LED references for Williams/Bally WPC boards.</p>
-        <a class="btn" href="https://raw.githubusercontent.com/wiki/warped-pinball/vector/wiki-pdf/WPC/WPC%20Quick%20Start.pdf">Download as PDF</a>
+        <button type="button" class="btn print-hidden" data-print-pdf>Download as PDF</button>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- replace static PDF links on guide pages with buttons that trigger browser printing of the current HTML
- add a shared print handler script and hide the controls when generating the PDF

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c74f6490c8330a2acc80425243c46)