### PR TITLE
Enable dark mode in documentation site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,10 @@ site_name: Vector Documentation
 site_url: https://warped-pinball.github.io/vector/
 theme:
   name: material
+  palette:
+    - scheme: slate
+      primary: blue
+      accent: blue
 nav:
   - Home: index.md
   - Guides:


### PR DESCRIPTION
### Motivation
- Configure the documentation site to use a dark appearance via the Material theme.
- Improve readability and visual consistency for users who prefer a dark palette.

### Description
- Updated the `mkdocs.yml` theme configuration to add a `palette` entry.
- Set `scheme: slate` with `primary: blue` and `accent: blue` under the `palette` to enable dark styling.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695db9e4db3883308a6d589051a2b464)