### PR TITLE
Add CNAME for MkDocs site deployment

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.warpedpinball.com


### PR DESCRIPTION
### Motivation
- Ensure the custom domain is included in the MkDocs site output so `mkdocs gh-deploy --force` will publish the `CNAME` to the `gh-pages` branch for the project's GitHub Pages site.

### Description
- Add `docs/CNAME` containing the custom domain `docs.warpedpinball.com` so MkDocs copies it into the generated site output.

### Testing
- No automated tests were run because this is a docs-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eef16b2b88330b9dca292b4722c5d)