### PR TITLE
Origin end of game retry increase

### DIFF
--- a/src/common/Formats.py
+++ b/src/common/Formats.py
@@ -601,13 +601,7 @@ def formats_run():
         call rate CALL_TIMER milli-seconds
     """
     global next_format, game_state, GameEndCount, player_scores, saved_high_scores, last_high_score_count, in_play_scores_hold, push_game_count, last_pushed_game
-
-    if push_game_count>0:
-        from origin import push_end_of_game
-        push_game_count+=1
-        push_end_of_game(last_pushed_game,push_game_count)
-        if push_game_count>3:
-            push_game_count =0
+   
 
     # Waiting to change format?
     active_id = S.active_format.get("Id", 0)
@@ -643,6 +637,13 @@ def formats_run():
                 handlers[HANDLER_INIT]()
             except Exception as e:
                 log.log(f"FORMAT: Error running init format {active_id}: {e}")
+        else:
+            if push_game_count>0:
+                from origin import push_end_of_game
+                push_game_count+=1
+                push_end_of_game(last_pushed_game,push_game_count)
+                if push_game_count>5:
+                    push_game_count =0
     
 
     # Call handler during game, wait for game end

--- a/src/common/Formats.py
+++ b/src/common/Formats.py
@@ -601,7 +601,13 @@ def formats_run():
         call rate CALL_TIMER milli-seconds
     """
     global next_format, game_state, GameEndCount, player_scores, saved_high_scores, last_high_score_count, in_play_scores_hold, push_game_count, last_pushed_game
-   
+       
+    if push_game_count>0:
+        from origin import push_end_of_game
+        push_game_count+=1
+        push_end_of_game(last_pushed_game,push_game_count)
+        if push_game_count>5:
+            push_game_count =0
 
     # Waiting to change format?
     active_id = S.active_format.get("Id", 0)
@@ -636,14 +642,7 @@ def formats_run():
             try:
                 handlers[HANDLER_INIT]()
             except Exception as e:
-                log.log(f"FORMAT: Error running init format {active_id}: {e}")
-        else:
-            if push_game_count>0:
-                from origin import push_end_of_game
-                push_game_count+=1
-                push_end_of_game(last_pushed_game,push_game_count)
-                if push_game_count>5:
-                    push_game_count =0
+                log.log(f"FORMAT: Error running init format {active_id}: {e}")       
     
 
     # Call handler during game, wait for game end

--- a/src/common/ScoreTrack.py
+++ b/src/common/ScoreTrack.py
@@ -441,7 +441,7 @@ def CheckForNewScores(nState=[0]):
         from origin import push_end_of_game
         push_game_count+=1
         push_end_of_game(last_pushed_game,push_game_count)
-        if push_game_count>3:
+        if push_game_count>5:
             push_game_count =0
 
     if nState[0] == 0:  # power up init

--- a/src/common/SharedState.py
+++ b/src/common/SharedState.py
@@ -1,4 +1,4 @@
-VectorVersion = "1.11.9"
+VectorVersion = "1.11.10"
 
 
 

--- a/src/common/origin.py
+++ b/src/common/origin.py
@@ -43,16 +43,16 @@ def push_game_state(game_report):
     send_origin_message("game_state", game_report)
 
 
-def push_end_of_game(game,try_count):
+def push_end_of_game(game, try_count):
     # game = [0, ['', 0], ['', 0], ['', 0], ['', 0]]
     # try_count is 1 for first attempt and then increments for retransmits
 
-    print("Pushing end_of_game:", game, " try:",try_count)
+    print("Pushing end_of_game:", game, " try:", try_count)
 
     # ensure list of tuples with initial, and score
     plays = []
     for play in game[1:]:
-        if len(play) == 2 and isinstance(play[0], str) and isinstance(play[1], int) and play[1] != 0:
+        if len(play) == 2 and isinstance(play[1], int) and play[1] != 0:
             if isinstance(play, tuple):
                 plays.append(list(play))
             else:
@@ -61,7 +61,7 @@ def push_end_of_game(game,try_count):
     if not plays:
         return
 
-    send_origin_message("end_of_game", {"plays": plays, "try": try_count, "game_num": game[0] })
+    send_origin_message("end_of_game", {"plays": plays, "try": try_count, "game_num": game[0]})
 
 
 def push_reset():

--- a/src/common/origin.py
+++ b/src/common/origin.py
@@ -61,7 +61,7 @@ def push_end_of_game(game,try_count):
     if not plays:
         return
 
-    send_origin_message("end_of_game", {"plays": plays, "try": try_count, "counter": game[0] })
+    send_origin_message("end_of_game", {"plays": plays, "try": try_count, "game_num": game[0] })
 
 
 def push_reset():

--- a/src/common/origin.py
+++ b/src/common/origin.py
@@ -47,8 +47,6 @@ def push_end_of_game(game, try_count):
     # game = [0, ['', 0], ['', 0], ['', 0], ['', 0]]
     # try_count is 1 for first attempt and then increments for retransmits
 
-    print("Pushing end_of_game:", game, " try:", try_count)
-
     # ensure list of tuples with initial, and score
     plays = []
     for play in game[1:]:

--- a/src/common/origin.py
+++ b/src/common/origin.py
@@ -61,7 +61,7 @@ def push_end_of_game(game,try_count):
     if not plays:
         return
 
-    send_origin_message("end_of_game", {"plays": plays, "try": try_count })
+    send_origin_message("end_of_game", {"plays": plays, "try": try_count, "counter": game[0] })
 
 
 def push_reset():

--- a/src/data_east/ScoreTrack.py
+++ b/src/data_east/ScoreTrack.py
@@ -295,7 +295,7 @@ def CheckForNewScores():
         from origin import push_end_of_game
         push_game_count+=1
         push_end_of_game(last_pushed_game,push_game_count)
-        if push_game_count>3:
+        if push_game_count>5:
             push_game_count =0
 
     print(f"SCORE: CheckForNewScores - State={_game_state}, GameEndCount={GameEndCount}, IdleCounter={nGameIdleCounter}")

--- a/src/data_east/systemConfig.py
+++ b/src/data_east/systemConfig.py
@@ -2,7 +2,7 @@ vectorSystem = "data_east"
 updatesURL = "http://software.warpedpinball.com/vector/data_east/latest.json"
 
 # Firmware version for the Data East build
-SystemVersion = "1.0.3"
+SystemVersion = "1.0.4"
 
 
 # System specific scheduled tasks

--- a/src/wpc/ScoreTrack.py
+++ b/src/wpc/ScoreTrack.py
@@ -516,6 +516,13 @@ def CheckForNewScores(nState=[0]):
     """called by scheduler every 5 seconds"""
     global nGameIdleCounter, GameEndCount, initials_capture_this_game, live_scores, push_game_count, last_pushed_game  
 
+    if push_game_count>0:
+        from origin import push_end_of_game
+        push_game_count+=1        
+        push_end_of_game(last_pushed_game,push_game_count)
+        if push_game_count>5:
+            push_game_count =0
+
     # power up init state - only runs once
     if nState[0] == 0:
         import machine
@@ -570,14 +577,7 @@ def CheckForNewScores(nState=[0]):
                     initials_capture_this_game = True
                 else:
                     initials_capture_this_game = False
-                S.gameCounter = (S.gameCounter + 1) % 100
-            else:
-                if push_game_count>0:
-                    from origin import push_end_of_game
-                    push_game_count+=1        
-                    push_end_of_game(last_pushed_game,push_game_count)
-                    if push_game_count>5:
-                        push_game_count =0
+                S.gameCounter = (S.gameCounter + 1) % 100       
         
 
         # waiting for game to end

--- a/src/wpc/ScoreTrack.py
+++ b/src/wpc/ScoreTrack.py
@@ -514,16 +514,7 @@ last_pushed_game = [["", 0], ["", 0], ["", 0], ["", 0]]
 
 def CheckForNewScores(nState=[0]):
     """called by scheduler every 5 seconds"""
-    global nGameIdleCounter, GameEndCount, initials_capture_this_game, live_scores, push_game_count, last_pushed_game
-
-
-    if push_game_count>0:
-        from origin import push_end_of_game
-        push_game_count+=1        
-        push_end_of_game(last_pushed_game,push_game_count)
-        if push_game_count>3:
-            push_game_count =0
-        
+    global nGameIdleCounter, GameEndCount, initials_capture_this_game, live_scores, push_game_count, last_pushed_game  
 
     # power up init state - only runs once
     if nState[0] == 0:
@@ -580,6 +571,14 @@ def CheckForNewScores(nState=[0]):
                 else:
                     initials_capture_this_game = False
                 S.gameCounter = (S.gameCounter + 1) % 100
+            else:
+                if push_game_count>0:
+                    from origin import push_end_of_game
+                    push_game_count+=1        
+                    push_end_of_game(last_pushed_game,push_game_count)
+                    if push_game_count>5:
+                        push_game_count =0
+        
 
         # waiting for game to end
         elif nState[0] == 2:

--- a/src/wpc/systemConfig.py
+++ b/src/wpc/systemConfig.py
@@ -2,7 +2,7 @@ vectorSystem = "wpc"
 updatesURL = "http://software.warpedpinball.com/vector/wpc/latest.json"
 
 # Firmware version for the WPC build
-SystemVersion = "1.7.4"
+SystemVersion = "1.7.5"
 
 
 # System specific scheduled tasks


### PR DESCRIPTION
## Description
When sending end of game messages to Origin - increase retransmit from 4 to 6
Include a new item in the message - "counter" that increments for each game (roll over at 100)
Stop sending retransmits if a new game starts

## Related Issues
<!--- Link to any open issues this PR addresses, e.g., Closes #123 or Resolves #456 -->

## Motivation and Context
<!--- Explain why this change is required and what problem it solves -->

## Testing
<!--- Describe your testing steps, environments, and any relevant details -->

## Screenshots (if applicable)
<!--- Add screenshots if appropriate -->

## Types of Changes
- [ ] Bug fix (non-breaking change to resolve an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] Documentation update required

## Checklist
- [ ] My code follows the project’s style guidelines.
- [ ] I have updated documentation as needed.
- [ ] I have read the CONTRIBUTING.md document.
- [ ] I have added or updated tests.
- [ ] All new and existing tests pass.

## Additional Notes
<!--- Add any extra information here -->
