### PR TITLE
Add logic to remove extra files and update files in build_update_file…

### DIFF
--- a/dev/build_update.py
+++ b/dev/build_update.py
@@ -257,6 +257,10 @@ def build_update_file(
             make_file_line("update.mpy", get_file_contents(update_file_path), custom_log=f"Uploading {update_file_path}"),
         )
     else:
+        # remove extra files
+        file_lines.append(build_remove_extra_files_code(build_dir))
+
+        # update files
         for root, _, files in os.walk(build_dir_path):
             for file_name in sorted(files):
                 file_path = Path(root) / file_name

--- a/dev/build_update.py
+++ b/dev/build_update.py
@@ -173,6 +173,9 @@ def build_remove_extra_files_code(build_dir: str) -> bytes:
             relative_path = os.path.relpath(file_path, build_dir)
             known_files.append("/" + relative_path.replace("\\", "/"))
 
+    # add update.json to known files since it won't be in the build dir but we don't want to delete it(yet)
+    known_files.append("/update.json")
+
     removal_code = "\n".join(
         [
             "import os",
@@ -200,6 +203,28 @@ def build_remove_extra_files_code(build_dir: str) -> bytes:
         "remove_extra_files.py",
         removal_code.encode("utf-8"),
         custom_log="Removing extra files from previous versions",
+        execute=True,
+    )
+
+
+def build_remove_update_file_code() -> bytes:
+    """
+    Build a Micropython script that removes the update file itself. This is used at the end of the update process to clean up.
+    Return it as raw bytes ready for base64 encoding.
+    """
+    code = "\n".join(
+        [
+            "import os",
+            "try:",
+            "    os.remove('/update.json')",
+            "except OSError:",
+            "    pass",
+        ]
+    )
+    return make_file_line(
+        "remove_update_file.py",
+        code.encode("utf-8"),
+        custom_log="Cleaning up update file",
         execute=True,
     )
 
@@ -267,7 +292,10 @@ def build_update_file(
                 relative_path = os.path.relpath(file_path, build_dir_path).replace("\\", "/")
                 file_lines.append(make_file_line(relative_path, get_file_contents(str(file_path))))
 
-    # 3) Sign everything except the signature line:
+    # remove update file at the end of the process
+    file_lines.append(build_remove_update_file_code())
+
+    # Sign everything except the signature line:
     # Concatenate metadata_line plus all file_lines with newlines in between.
     update_body = "\n".join(file_lines)
     sha256_hex, signature_b64 = sign_data(update_body.encode("utf-8"), private_key_path)

--- a/dev/build_update.py
+++ b/dev/build_update.py
@@ -173,9 +173,6 @@ def build_remove_extra_files_code(build_dir: str) -> bytes:
             relative_path = os.path.relpath(file_path, build_dir)
             known_files.append("/" + relative_path.replace("\\", "/"))
 
-    # add update.json to known files since it won't be in the build dir but we don't want to delete it(yet)
-    # known_files.append("/update.json")
-
     removal_code = "\n".join(
         [
             "import os",

--- a/dev/build_update.py
+++ b/dev/build_update.py
@@ -174,7 +174,7 @@ def build_remove_extra_files_code(build_dir: str) -> bytes:
             known_files.append("/" + relative_path.replace("\\", "/"))
 
     # add update.json to known files since it won't be in the build dir but we don't want to delete it(yet)
-    known_files.append("/update.json")
+    # known_files.append("/update.json")
 
     removal_code = "\n".join(
         [


### PR DESCRIPTION
## Description

Adds back the "build_remove_extra_files_code" function to the updates; but not to the "tiny" update since that doesn't contain any of the main build so we don't want to delete any of the existing files. 
