### PR TITLE
Bride of Pinbot Calibration Issue - RamFill

### DIFF
--- a/dev/generated/specialfeatures.csv
+++ b/dev/generated/specialfeatures.csv
@@ -25,7 +25,7 @@ Tales from the Crypt,DATA_EAST,500,yes,no,yes,Limbo;LongestBall;LowBall;Practice
 Teenage Mutant Ninja Turtles,DATA_EAST,104,yes,no,yes,Limbo;LongestBall;LowBall;Practice;Standard
 The Simpsons,DATA_EAST,27,yes,no,yes,Limbo;LongestBall;LowBall;Practice;Standard
 Time Machine,DATA_EAST,a24,yes,no,yes,Limbo;LongestBall;LowBall;Practice;Standard
-Tomy,DATA_EAST,400,yes,no,yes,Limbo;LongestBall;LowBall;Practice;Standard
+Tommy Pinball Wizard,DATA_EAST,400,yes,no,yes,Limbo;LongestBall;LowBall;Practice;Standard
 Torpedo Alley,DATA_EAST,21,yes,no,yes,Limbo;LongestBall;LowBall;Practice;Standard
 EM machine,EM,,yes,no,no,
 Bad Cats,SYS11,LA5,no,no,no,
@@ -85,8 +85,8 @@ Jack Bot,WPC,04A;10R,yes,yes,yes,Golf;HalfLife;Limbo;LongestBall;LowBall;Practic
 Johnny Mnemonic,WPC,11R;12R,yes,yes,no,
 Judge Dredd,WPC,L7,yes,yes,no,
 Junk Yard,WPC,10;12,yes,yes,no,
-Machine Bride of Pinbot,WPC,L7;L8,yes,yes,no,
-Medeival Madness,WPC,L4,yes,yes,no,
+Machine Bride of Pinbot,WPC,L5;L7;L8,yes,yes,yes,HalfLife;Limbo;LongestBall;LowBall;Practice;Standard
+Medieval Madness,WPC,L4,yes,yes,yes,HalfLife;Limbo;LongestBall;LowBall;Practice;Standard
 Monster Bash,WPC,10,yes,yes,no,
 No Fear Dangerous Sports,WPC,23x,yes,yes,no,
 No Good Gofers,WPC,13,yes,yes,no,
@@ -98,7 +98,7 @@ Scared Stiff,WPC,15,yes,yes,no,
 Star Trek: TNG,WPC,LX7;LX8,yes,yes,no,
 Tales of the Arabian Nights,WPC,14,yes,yes,no,
 Terminator 2,WPC,L8;L84,yes,yes,no,
-The Flinstones,WPC,LX5,yes,yes,no,
+The Flintstones,WPC,LX5,yes,yes,yes,HalfLife;Limbo;LongestBall;LowBall;Practice;Standard
 The Getaway: High Speed II,WPC,L2,yes,no,no,
 The Shadow,WPC,LX5,yes,yes,no,
 Theatre of Magic,WPC,13;14HB;20,yes,yes,no,

--- a/src/common/SharedState.py
+++ b/src/common/SharedState.py
@@ -1,4 +1,4 @@
-VectorVersion = "1.11.14"
+VectorVersion = "1.11.15"
 
 
 

--- a/src/common/SharedState.py
+++ b/src/common/SharedState.py
@@ -1,4 +1,4 @@
-VectorVersion = "1.11.15"
+VectorVersion = "1.11.16"
 
 
 

--- a/src/common/SharedState.py
+++ b/src/common/SharedState.py
@@ -1,4 +1,4 @@
-VectorVersion = "1.11.17"
+VectorVersion = "1.11.18"
 
 
 

--- a/src/wpc/config/MachineBride_L5.json
+++ b/src/wpc/config/MachineBride_L5.json
@@ -6,41 +6,41 @@
   },
   "BallInPlay": {
       "Type": 1,
-      "Address": 949
+      "Address": 944
   },
   "DisplayMessage": {
       "Type": 10,
-      "AddressS1": 7642,
-      "AddressS2": 7707,
-      "AddressS3": 7772,
+      "AddressS1": 7552,
+      "AddressS2": 7617,
+      "AddressS3": 7682,
       "Length": 32,
-      "ChecksumStartAdr": 7642,
-      "ChecksumEndAdr": 7834,
-      "ChecksumResultAdr": 7835
+      "ChecksumStartAdr": 7552,
+      "ChecksumEndAdr": 7744,
+      "ChecksumResultAdr": 7745
   },
   "Adjustments": {
       "Type": 10,
-      "CustomMessageOn": 7072,
-      "ChecksumStartAdr": 7031,
-      "ChecksumEndAdr": 7250,
-      "ChecksumResultAdr": 7251
+      "CustomMessageOn": 6982,
+      "ChecksumStartAdr": 7338,
+      "ChecksumEndAdr": 7549,
+      "ChecksumResultAdr": 7550
   },
   "HighScores": {
       "Type": 10,
-      "ScoreAdr": 7358,
+      "ScoreAdr": 7247,
       "BytesInScore": 5,
       "ScoreSpacing": 8,
-      "InitialAdr": 7355,
+      "InitialAdr": 7244,
       "InitialSpacing": 8,
       "NumberOfScores": 4,
-      "GrandChampScoreAdr": 7392,
-      "GrandChampInitAdr": 7389,
-      "ChecksumStartAdr": 7355,
-      "ChecksumEndAdr": 7386,
-      "ChecksumResultAdr": 7387,
-      "GCChecksumStartAdr": 7389,
-      "GCChecksumEndAdr": 7396,
-      "GCChecksumResultAdr": 7397
+      "GrandChampScoreAdr": 7281,
+      "GrandChampInitAdr": 7278,
+      "ChecksumStartAdr": 7244,
+      "ChecksumEndAdr": 7275,
+      "ChecksumResultAdr": 7276,
+      "GCChecksumStartAdr": 7278,
+      "GCChecksumEndAdr": 7309,
+      "GCChecksumResultAdr": 7310
   },
   "HSRewards": {
       "Type": 0,
@@ -55,15 +55,15 @@
       "Type": 10,
       "GameActiveAdr": 141,
       "GameActiveValue": 0,
-      "Players": 6044,
-      "PlayerUp": 1038,
-      "ScoreAdr": 5936,
+      "Players": 6059,
+      "PlayerUp": 1032,
+      "ScoreAdr": 5952,
       "ScoreBytes": 5,
       "ScoreSpacing": 6
   },
   "Switches": {
     "Type": 10,
-    "Address": 5975,
+    "Address": 5991,
     "Length": 55,
     "Names": [
       ["Right Flipper", 60],
@@ -118,7 +118,7 @@
       ["Head Mouth", 60],
       [],
       ["Face Position", 60],
-      ["Right Slingshot", 60],
+      [],
 
       ["Wireform Top", 60],
       ["Wireform Bottom", 60],
@@ -130,8 +130,8 @@
     ]
   },
   "RamFill": {
-      "Start": 8129,
-      "End": 8138,
+      "Start": 8039,
+      "End": 8058,
       "Value": 0
   },
   "Formats": {

--- a/src/wpc/config/MachineBride_L5.json
+++ b/src/wpc/config/MachineBride_L5.json
@@ -129,11 +129,7 @@
       ["Right Ramp Enter", 60]
     ]
   },
-  "RamFill": {
-      "Start": 8039,
-      "End": 8058,
-      "Value": 0
-  },
+  "RamFill": [8039, 8058, 0],
   "Formats": {
       "Standard": {
           "Id": 0

--- a/src/wpc/config/MachineBride_L7.json
+++ b/src/wpc/config/MachineBride_L7.json
@@ -129,11 +129,7 @@
       ["Right Ramp Enter", 60]
     ]
   },
-  "RamFill": {
-      "Start": 8129,
-      "End": 8138,
-      "Value": 0
-  },
+  "RamFill": [8129, 8138, 0],
   "Formats": {
       "Standard": {
           "Id": 0

--- a/src/wpc/config/MachineBride_L7.json
+++ b/src/wpc/config/MachineBride_L7.json
@@ -128,5 +128,33 @@
       ["Left Ramp Enter", 60],
       ["Right Ramp Enter", 60]
     ]
+  },
+  "RamFill": {
+      "Start": 8129,
+      "End": 8138,
+      "Value": 0
+  },
+  "Formats": {
+      "Standard": {
+          "Id": 0
+      },
+      "Limbo": {
+          "Id": 1
+      },
+      "LowBall": {
+          "Id": 2
+      },
+      "Practice": {
+          "Id": 4
+      },
+      "HalfLife": {
+          "Id": 5
+      },
+      "LongestBall": {
+          "Id": 6
+      },
+      "OneBall": {
+          "Id": 7
+      }
   }
 }

--- a/src/wpc/config/MachineBride_L8.json
+++ b/src/wpc/config/MachineBride_L8.json
@@ -129,11 +129,7 @@
       ["Right Ramp Enter", 60]
     ]
   },
-  "RamFill": {
-      "Start": 8129,
-      "End": 8138,
-      "Value": 0
-  },
+  "RamFill": [8129, 8138, 0],
   "Formats": {
       "Standard": {
           "Id": 0

--- a/src/wpc/main.py
+++ b/src/wpc/main.py
@@ -132,11 +132,14 @@ else:
 if not bus_activity_fault:
     MemoryMain.go()
 
-# Test code: Check for Machine Bride of Pinbot and set shadow RAM location 8138
-if SharedState.gdata.get("GameInfo", {}).get("GameName") == "Machine Bride of Pinbot":
-    shadowRam[8138] = 0xFF
-    print("DEBUG: Set shadowRam[8138] to 0xFF for Machine Bride of Pinbot")
-
+ram_fill = SharedState.gdata.get("RamFill")
+if ram_fill:
+    fill_start = ram_fill["Start"]
+    fill_end = ram_fill["End"]
+    fill_value = ram_fill["Value"]
+    for addr in range(fill_start, fill_end + 1):
+        shadowRam[addr] = fill_value
+    Log.log(f"Main: RamFill {fill_start}-{fill_end} = {fill_value}")
 
 import Time
 Time.initialize()

--- a/src/wpc/main.py
+++ b/src/wpc/main.py
@@ -22,6 +22,8 @@ from machine import Pin
 
 import Switches
 import Formats
+import SharedState
+from Shadow_Ram_Definitions import shadowRam
 
 Log = logger_instance
 # other gen I/O pin inits
@@ -129,6 +131,11 @@ else:
 
 if not bus_activity_fault:
     MemoryMain.go()
+
+# Test code: Check for Machine Bride of Pinbot and set shadow RAM location 8138
+if SharedState.gdata.get("GameInfo", {}).get("GameName") == "Machine Bride of Pinbot":
+    shadowRam[8138] = 0xFF
+    print("DEBUG: Set shadowRam[8138] to 0xFF for Machine Bride of Pinbot")
 
 
 import Time

--- a/src/wpc/main.py
+++ b/src/wpc/main.py
@@ -134,9 +134,7 @@ if not bus_activity_fault:
 
 ram_fill = SharedState.gdata.get("RamFill")
 if ram_fill:
-    fill_start = ram_fill["Start"]
-    fill_end = ram_fill["End"]
-    fill_value = ram_fill["Value"]
+    fill_start, fill_end, fill_value = ram_fill
     for addr in range(fill_start, fill_end + 1):
         shadowRam[addr] = fill_value
     Log.log(f"Main: RamFill {fill_start}-{fill_end} = {fill_value}")

--- a/src/wpc/systemConfig.py
+++ b/src/wpc/systemConfig.py
@@ -2,7 +2,7 @@ vectorSystem = "wpc"
 updatesURL = "http://software.warpedpinball.com/vector/wpc/latest.json"
 
 # Firmware version for the WPC build
-SystemVersion = "1.7.8"
+SystemVersion = "1.7.9"
 
 
 # System specific scheduled tasks


### PR DESCRIPTION
## Description
Add optional RamFill dict to config json and code in main to execute a fill operation in shadowram
In this case used to zero out the head rotation calibration in Bride of Pinbot

## Related Issues
<!--- Link to any open issues this PR addresses, e.g., Closes #123 or Resolves #456 -->

## Motivation and Context
The calibration and position of the head is re-written during operation often.
If we have a power off before the ram is copied to FRAM the calibration position is incorrect.
This forces a re-cal on start up avoiding the need for a continuous fast copy

## Testing
Customer tests complete

## Screenshots (if applicable)
<!--- Add screenshots if appropriate -->

## Types of Changes
- [ ] Bug fix (non-breaking change to resolve an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] Documentation update required

## Checklist
- [ ] My code follows the project’s style guidelines.
- [ ] I have updated documentation as needed.
- [ ] I have read the CONTRIBUTING.md document.
- [ ] I have added or updated tests.
- [ ] All new and existing tests pass.

## Additional Notes
<!--- Add any extra information here -->
