### PR TITLE
Add --test-data flag to sync.py

### DIFF
--- a/dev/readme.md
+++ b/dev/readme.md
@@ -42,6 +42,11 @@ To automatically detect and flash all connected boards, run:
 ```bash
 python dev/sync.py auto
 ```
+Additional Parameters:
+
+| Option | Description |
+|--------|-------------|
+| `--test-data` | Syncs test_data.json to the board (overwrites data) |
 
 Each board is identified, firmware for each hardware platform is built once,
 and all boards are flashed in parallel. Build artifacts are always written to

--- a/dev/sync.py
+++ b/dev/sync.py
@@ -15,7 +15,7 @@ REPL_ATTEMPTS = 10
 REPL_DELAY = 1
 
 
-def flash_single(system: str, port: Optional[str], write_config: Optional[str]) -> int:
+def flash_single(system: str, port: Optional[str], write_config: Optional[str], test_data: Optional[bool]) -> int:
     """Build *system* firmware and flash a single board."""
     build_dir = build_for_hardware(system)
     cmd = ["python", "dev/flash.py", build_dir]
@@ -26,6 +26,8 @@ def flash_single(system: str, port: Optional[str], write_config: Optional[str]) 
             cmd.append("--write-config")
         else:
             cmd.extend(["--write-config", write_config])
+    if test_data:
+        cmd.extend(["--test-data"])
     return subprocess.call(cmd)
 
 
@@ -51,6 +53,11 @@ def main(argv: list[str]) -> int:
         metavar="PATH",
         help=("Pass through to flash.py: wipe config on Pico and write configuration from PATH. " "If provided with no PATH, uses the default config for the selected build_dir."),
     )
+    parser.add_argument(
+        "--test-data",
+        action="store_true",
+        help="Write test data from test_data.json to Pico.",
+    )
     args = parser.parse_args(argv[1:])
 
     if args.system == "auto":
@@ -61,7 +68,7 @@ def main(argv: list[str]) -> int:
         print("Boards detected:", json.dumps(mapping))
         return build_and_flash(mapping, write_config=args.write_config)
 
-    rc = flash_single(args.system, args.port, args.write_config)
+    rc = flash_single(args.system, args.port, args.write_config, args.test_data)
     if rc == 0:
         open_repl(args.port)
     return rc

--- a/src/common/backend.py
+++ b/src/common/backend.py
@@ -2098,6 +2098,7 @@ def connect_to_wifi(initialize=False):
     wifi_credentials = ds_read_record("configuration", 0)
     ssid = wifi_credentials["ssid"]
     password = wifi_credentials["password"]
+    print(f"SSID: {ssid}")
 
     if not ssid:
         return False

--- a/src/common/backend.py
+++ b/src/common/backend.py
@@ -2098,7 +2098,7 @@ def connect_to_wifi(initialize=False):
     wifi_credentials = ds_read_record("configuration", 0)
     ssid = wifi_credentials["ssid"]
     password = wifi_credentials["password"]
-    print(f"SSID: {ssid}")
+    print("Connecting to SSID: {ssid}")
 
     if not ssid:
         return False


### PR DESCRIPTION
## Description
Adds `--test-data` flag to sync.py for optional data sync. 

I believe it used to always sync, but it seems like it's been made an option on flash.py at some point. I've added the same option to sync.py to pass over if it exists.

... Also prints the SSID on board startup.... was debugging my own wifi and this was useful.

## Testing
Example Command:
```
python dev/sync.py sys11 /dev/cu.usbmodem101 --test-data
```

## Types of Changes
- [ ] Bug fix (non-breaking change to resolve an issue)
- [x] New feature (non-breaking change to add functionality)
- [ ] Breaking change (alters existing functionality)
- [x] Documentation update required

## Checklist
- [x] My code follows the project’s style guidelines.
- [x] I have updated documentation as needed.
- [ ] I have read the CONTRIBUTING.md document.
- [ ] I have added or updated tests.
- [ ] All new and existing tests pass.

