### PR TITLE
bus activity fault turned off for System 11 Test

### DIFF
--- a/src/common/SharedState.py
+++ b/src/common/SharedState.py
@@ -1,4 +1,4 @@
-VectorVersion = "1.11.22"
+VectorVersion = "1.11.23"
 
 
 

--- a/src/common/main.py
+++ b/src/common/main.py
@@ -122,6 +122,7 @@ ap_mode = check_ap_button()
 print("Main: AP mode = ", ap_mode)
 
 bus_activity_fault = bus_activity_fault_check()
+bus_activity_fault = False
 if bus_activity_fault:
     set_error_led()
     faults.raise_fault(faults.HDWR01)


### PR DESCRIPTION
## Description
Have a System 11 in the field with new Rotten Dog board that gets Bus Activity fault.
This is a test version turning that fault detection off (results of test still logged)

## Related Issues
<!--- Link to any open issues this PR addresses, e.g., Closes #123 or Resolves #456 -->

## Motivation and Context
<!--- Explain why this change is required and what problem it solves -->

## Testing
<!--- Describe your testing steps, environments, and any relevant details -->

## Screenshots (if applicable)
<!--- Add screenshots if appropriate -->

## Types of Changes
- [ ] Bug fix (non-breaking change to resolve an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] Documentation update required

## Checklist
- [ ] My code follows the project’s style guidelines.
- [ ] I have updated documentation as needed.
- [ ] I have read the CONTRIBUTING.md document.
- [ ] I have added or updated tests.
- [ ] All new and existing tests pass.

## Additional Notes
<!--- Add any extra information here -->
