### PR TITLE
Disable wifi power-save mode to fix dropped packets and unreachable web UI

### DIFF
--- a/src/common/SharedState.py
+++ b/src/common/SharedState.py
@@ -1,4 +1,4 @@
-VectorVersion = "1.11.23"
+VectorVersion = "1.11.24"
 
 
 

--- a/src/common/phew/__init__.py
+++ b/src/common/phew/__init__.py
@@ -45,6 +45,7 @@ def reconnect_to_wifi():
     try:
         wlan = network.WLAN(network.STA_IF)
         wlan.active(True)
+        wlan.config(pm=0xA11140)  # disable power save; dozing radio drops packets
         wlan.connect()
     except Exception as e:
         logging.error(f"Failed to reconnect to wifi: {e}")
@@ -67,6 +68,7 @@ def connect_to_wifi(ssid, password, timeout_seconds=30):
 
     wlan = network.WLAN(network.STA_IF)
     wlan.active(True)
+    wlan.config(pm=0xA11140)  # disable power save; dozing radio drops packets
     wlan.connect(ssid, password)
     start = time.ticks_ms()
     status = wlan.status()


### PR DESCRIPTION
## Problem

Vector runs an always-on web server on the Pico W. With the CYW43 wifi chip's default power-management mode, the radio periodically dozes between beacons. While dozing it can miss or drop incoming packets, which shows up as slow page loads, intermittent timeouts, and the web UI becoming unreachable until traffic (or a reboot) wakes the radio. Since a pinball machine sits idle between games, the radio spends a lot of time dozed exactly when someone tries to pull up the scoreboard.

## Fix

Set `wlan.config(pm=0xA11140)` (= `network.WLAN.PM_NONE`, i.e. power-save disabled) immediately after `wlan.active(True)` in both wifi connect paths in `src/common/phew/__init__.py` (`connect_to_wifi` and `reconnect_to_wifi`).

The board is powered from the machine, so the small extra radio power draw is irrelevant here — reliability is what matters.

Also bumps `VectorVersion` 1.11.23 → 1.11.24 to satisfy the version-bump guard.

## Supporting references

- **Official Raspberry Pi documentation**, *Connecting to the Internet with Raspberry Pi Pico W* — the "Disable powersaving" section explicitly recommends `wlan.config(pm = 0xa11140)` when running a server on the Pico W: https://datasheets.raspberrypi.com/picow/connecting-to-the-internet-with-pico-w.pdf
- **MicroPython docs**, `network.WLAN` — defines `PM_NONE` ("disable wifi power management") alongside `PM_PERFORMANCE`/`PM_POWERSAVE`: https://docs.micropython.org/en/latest/library/network.WLAN.html

## Testing

Running on our machine (WPC) — the web UI no longer goes unreachable after idle periods and page loads are consistently fast.

Worth noting: the stock code worked fine when we tested at home, but at the location where the machine actually operates — a different access point — Vector was effectively unusable until we made this change. Whether power-save bites appears to depend on the AP's beacon/DTIM behavior, so you may not be able to reproduce the problem on your own network even though it's severe on others. Disabling power-save makes behavior consistent regardless of which AP the machine ends up on, which is the situation for operators who don't control the venue's network gear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
