### PR TITLE
Print() override to non-blocking

### DIFF
--- a/src/common/SharedState.py
+++ b/src/common/SharedState.py
@@ -1,4 +1,4 @@
-VectorVersion = "1.11.26"
+VectorVersion = "1.11.27"
 
 
 

--- a/src/common/main.py
+++ b/src/common/main.py
@@ -6,6 +6,7 @@
     fault check updated for early sys11 game compatability
 """
 
+import nonblocking_print  # noqa: F401  -- must be first; installs non-blocking print()
 import resource
 import time
 

--- a/src/common/nonblocking_print.py
+++ b/src/common/nonblocking_print.py
@@ -1,0 +1,55 @@
+# This file is part of the Warped Pinball Vector Project.
+# https://creativecommons.org/licenses/by-nc/4.0/
+# This work is licensed under CC BY-NC 4.0
+"""
+Non-blocking stdout for USB serial.
+
+When the host PC stops draining the USB CDC serial (e.g. it goes to sleep),
+MicroPython's built-in print() blocks the cooperative scheduler waiting for
+TX FIFO space. Importing this module replaces the built-in print() with a
+version that drops output when the host isn't reading, so the Pico keeps
+running normally and never stacks up a backlog.
+
+Delivery-critical traffic (the USB API responses in usb_comms) must NOT be
+dropped while the host is awake, so it uses reliable_print() instead, which
+keeps the original (blocking, but bounded by the firmware CDC TX timeout)
+behavior.
+
+Import this FIRST in main.py so every later print() is covered.
+"""
+import builtins
+import sys
+import uselect
+
+# Capture the native (blocking) print before we override it. Used for
+# delivery-critical output that must arrive intact while the host is awake.
+reliable_print = builtins.print
+
+_stdout = sys.stdout
+_poll = uselect.poll()
+_poll.register(_stdout, uselect.POLLOUT)
+_CHUNK = 64
+
+
+def safe_print(*args, sep=" ", end="\n"):
+    """Fire-and-forget print: drop output if the USB host isn't draining."""
+    try:
+        msg = sep.join(str(a) for a in args) + end
+    except Exception:
+        return
+    i = 0
+    n = len(msg)
+    while i < n:
+        if not _poll.poll(0):  # TX FIFO full -> host not reading, drop remainder
+            return
+        try:
+            written = _stdout.write(msg[i:i + _CHUNK])
+        except Exception:
+            return
+        if not written:
+            return
+        i += written
+
+
+# Install the non-blocking print globally for every bare print() in the project.
+builtins.print = safe_print

--- a/src/common/usb_comms.py
+++ b/src/common/usb_comms.py
@@ -2,6 +2,7 @@ import json
 import sys
 
 import uselect
+from nonblocking_print import reliable_print
 from phew.server import Request, Response, _routes, catchall_handler
 
 incoming_data = []  # complete lines only
@@ -167,8 +168,11 @@ def usb_request_handler():
 
         try:
             response_text = handle_usb_api_request(route_url, headers, data)
-            # This is how the response is sent back to the device
-            print(f"USB API RESPONSE-->{response_text}")
+            # This is how the response is sent back to the device.
+            # Use reliable_print (blocking, bounded by the firmware CDC TX
+            # timeout) so the response is never dropped/truncated while the
+            # host is awake -- unlike the non-blocking print() used elsewhere.
+            reliable_print(f"USB API RESPONSE-->{response_text}")
         except Exception as e:
             print(f"USB REQ: error processing request: {e}")
             # Continue processing other requests even if one fails

--- a/src/data_east/main.py
+++ b/src/data_east/main.py
@@ -8,6 +8,7 @@
     fault check updated for early sys11 game compatibility
 """
 
+import nonblocking_print  # noqa: F401  -- must be first; installs non-blocking print()
 
 #allocate DMA - wifi chip channel now
 import Pico_Led

--- a/src/data_east/systemConfig.py
+++ b/src/data_east/systemConfig.py
@@ -2,7 +2,7 @@ vectorSystem = "data_east"
 updatesURL = "http://software.warpedpinball.com/vector/data_east/latest.json"
 
 # Firmware version for the Data East build
-SystemVersion = "1.0.11"
+SystemVersion = "1.0.12"
 
 
 # System specific scheduled tasks

--- a/src/em/main.py
+++ b/src/em/main.py
@@ -8,6 +8,7 @@
     fault check updated for early sys11 game compatability
 """
 
+import nonblocking_print  # noqa: F401  -- must be first; installs non-blocking print()
 import resource
 import time
 

--- a/src/em/systemConfig.py
+++ b/src/em/systemConfig.py
@@ -2,5 +2,5 @@ vectorSystem = "em"
 updatesURL = "http://software.warpedpinball.com/vector/em/latest.json"
 
 # Firmware version for the EM build
-SystemVersion = "1.6.4"
+SystemVersion = "1.6.5"
 

--- a/src/wpc/main.py
+++ b/src/wpc/main.py
@@ -8,6 +8,7 @@
     fault check updated for early sys11 game compatability
 """
 
+import nonblocking_print  # noqa: F401  -- must be first; installs non-blocking print()
 import resource
 import time
 

--- a/src/wpc/systemConfig.py
+++ b/src/wpc/systemConfig.py
@@ -2,7 +2,7 @@ vectorSystem = "wpc"
 updatesURL = "http://software.warpedpinball.com/vector/wpc/latest.json"
 
 # Firmware version for the WPC build
-SystemVersion = "1.7.10"
+SystemVersion = "1.7.11"
 
 
 # System specific scheduled tasks


### PR DESCRIPTION
## Description
When a connected USB serial host pauses (connected pc goes to sleep, or connected accessory code crashes) with the port open the print statements still run in blocking mode with a ~500mS timeout on each.  This builds a large delay, holding up the micro python main line.  this change detects the full buffer and skips printing instead of blocking.

## Related Issues
<!--- Link to any open issues this PR addresses, e.g., Closes #123 or Resolves #456 -->

## Motivation and Context
This has been a known (minor) issue for bench debugging - however with new uses for the usb port- connecting to 3rd party accessories this becomes more important.  If the connected device pauses or fails we want to prevent any service degradation on our side.

## Testing
WPC & classic versions complete on the bench

## Screenshots (if applicable)
<!--- Add screenshots if appropriate -->

## Types of Changes
- [x] Bug fix (non-breaking change to resolve an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] Documentation update required

## Checklist
- [ ] My code follows the project’s style guidelines.
- [ ] I have updated documentation as needed.
- [ ] I have read the CONTRIBUTING.md document.
- [ ] I have added or updated tests.
- [ ] All new and existing tests pass.

## Additional Notes
<!--- Add any extra information here -->
