### PR TITLE
Data East - 6 digit scores fix and other config fixes

### DIFF
--- a/src/common/SharedState.py
+++ b/src/common/SharedState.py
@@ -1,4 +1,4 @@
-VectorVersion = "1.11.27"
+VectorVersion = "1.11.28"
 
 
 

--- a/src/data_east/DataMapper.py
+++ b/src/data_east/DataMapper.py
@@ -181,6 +181,23 @@ def read_high_scores():
     return highScores
 
 
+def remove_machine_scores():
+    """
+    Remove/reset machine high scores to prepare for forced initial entry.
+
+    Writes descending placeholder scores with blank initials (via
+    write_high_scores) so any score a player earns during the game
+    will beat a placeholder and trigger initials entry on the machine.
+    """
+    if "HighScores" not in S.gdata:
+        return
+
+    log.log(f"DATAMAPPER: Remove machine scores type {S.gdata['HighScores'].get('Type')}")
+
+    number_of_scores = S.gdata["HighScores"].get("NumberOfScores", 4)
+    placeholder_scores = [["", 600 - idx * 100] for idx in range(number_of_scores)]
+    write_high_scores(placeholder_scores)
+
 
 
 def write_high_scores(highScores):

--- a/src/data_east/DataMapper.py
+++ b/src/data_east/DataMapper.py
@@ -802,11 +802,11 @@ def enable_message(enable):
     """
         turn on/off display of the custom message
         fix checksum after messng with adjustment data
-    """ 
-    if enable:
-        shadowRam[S.gdata["Adjustments"]["CustomMessageOn"]]=1
-    else:
-        shadowRam[S.gdata["Adjustments"]["CustomMessageOn"]]=0
+    """
+    adr = S.gdata["Adjustments"].get("CustomMessageOn")
+    if not adr:
+        return
+    shadowRam[adr] = 1 if enable else 0
     _set_adjustment_checksum()
 
 

--- a/src/data_east/DataMapper.py
+++ b/src/data_east/DataMapper.py
@@ -737,7 +737,7 @@ def _set_adjustment_checksum():
         checksum=0
         for i in range(startAdr,endAdr+1):
             checksum = checksum + shadowRam[i]
-        shadowRam[resultAdr]=checksum
+        shadowRam[resultAdr]=checksum & 0xFF
 
 
 def turn_off_high_score_rewards():

--- a/src/data_east/DataMapper.py
+++ b/src/data_east/DataMapper.py
@@ -632,7 +632,7 @@ def get_live_scores(use_format=True):
                 scores[idx] = _bcd_to_int(score_bytes) * S.gdata["InPlay"].get("ScoreMultiplier", 1)
         
         elif S.gdata["InPlay"]["Type"] == 24:
-            # Type 21: Data East break after fourth byte, assume 5 bytes total
+            # Type 24: Data East break after fourth byte, assume 5 bytes total
             for idx in range(4):
                 score_start = S.gdata["InPlay"]["ScoreAdr"] + idx * 4
                 score_fifth_byte_adr = S.gdata["InPlay"]["ScoreAdr"] + 16 + idx
@@ -744,7 +744,7 @@ def turn_off_high_score_rewards():
     """
        turn_off_high_score_reward so it is not awarded on initials entry
     """
-    if S.gdata["Adjsutments"]["Type"] == 20:
+    if S.gdata["Adjustments"]["Type"] == 20:
         #DataStore.read_record("extras", 0)["enter_initials_on_game"]:
         print("SCORE: Disabling HS rewards")
         for key, value in S.gdata["HSRewards"].items():

--- a/src/data_east/config/BatmForever_401.json
+++ b/src/data_east/config/BatmForever_401.json
@@ -16,11 +16,11 @@
     },
     "DisplayMessage": {
         "Type": 20,
-        "Address": 8002
+        "Address": 8001
     },
     "Adjustments": {
         "Type": 20,
-        "CustomMessageOn": 7009,
+        "CustomMessageOn": 7755,
         "ChecksumStartAdr": 7678,
         "ChecksumEndAdr": 7807,
         "ChecksumResultAdr": 8125,
@@ -42,7 +42,7 @@
         "Type": 25,
         "Players": 465,
         "PlayerUp": 462,
-        "ScoreAdr": 1757,
+        "ScoreAdr": 5845,
         "BytesInScore": 5,
         "ScoreSpacing": 5,
         "Multiplier": 1

--- a/src/data_east/config/Baywatch_400.json
+++ b/src/data_east/config/Baywatch_400.json
@@ -40,7 +40,7 @@
         "Type": 25,
         "Players": 465,
         "PlayerUp": 462,
-        "ScoreAdr": 1758,
+        "ScoreAdr": 5845,
         "BytesInScore": 5,
         "ScoreSpacing": 5,
         "Multiplier": 1

--- a/src/data_east/config/Checkpoint_a17.json
+++ b/src/data_east/config/Checkpoint_a17.json
@@ -22,7 +22,7 @@
         "Type": 20,
         "CustomMessageOn": 0,
         "ChecksumStartAdr": 7680,
-        "ChecksumEndAdr": 7748,
+        "ChecksumEndAdr": 7749,
         "ChecksumResultAdr": 7934
     },
     "HighScores": {

--- a/src/data_east/config/Checkpoint_a17.json
+++ b/src/data_east/config/Checkpoint_a17.json
@@ -22,19 +22,19 @@
         "Type": 20,
         "CustomMessageOn": 0,
         "ChecksumStartAdr": 7680,
-        "ChecksumEndAdr": 7749,
+        "ChecksumEndAdr": 7748,
         "ChecksumResultAdr": 7934
     },
     "HighScores": {
         "Type": 20,
-        "ScoreAdr": 7582,
-        "BytesInScore": 6,
+        "ScoreAdr": 7584,
+        "BytesInScore": 4,
         "ScoreSpacing": 4,
         "Multiplier": 1,
         "InitialAdr": 7628,
         "InitialSpacing": 3,
         "NumberOfScores": 6,
-        "ScoreAdrNV": 7707
+        "ScoreAdrNV": 7709
     },
     "InPlay": {
         "Type": 20,

--- a/src/data_east/config/Frankenst_103.json
+++ b/src/data_east/config/Frankenst_103.json
@@ -12,7 +12,7 @@
     },
     "BallInPlay": {
         "Type": 20,
-        "Address": 407
+        "Address": 446
     },
     "DisplayMessage": {
         "Type": 20,

--- a/src/data_east/config/GunsNRoses_400.json
+++ b/src/data_east/config/GunsNRoses_400.json
@@ -20,7 +20,7 @@
     },
     "Adjustments": {
         "Type": 20,
-        "CustomMessageOn": 7694,
+        "CustomMessageOn": 7755,
         "ChecksumStartAdr": 7678,
         "ChecksumEndAdr": 7807,
         "ChecksumResultAdr": 8157

--- a/src/data_east/config/JurassicPark_513.json
+++ b/src/data_east/config/JurassicPark_513.json
@@ -38,7 +38,7 @@
     },
     "InPlay": {
         "Type": 24,
-        "Players": 425,
+        "Players": 428,
         "PlayerUp": 425,
         "ScoreAdr": 5844,
         "BytesInScore": 5,

--- a/src/data_east/config/LaserWar_a83.json
+++ b/src/data_east/config/LaserWar_a83.json
@@ -38,7 +38,7 @@
     "InPlay": {
         "Type": 20,
         "Players": 1610,
-        "PlayerUp": 205,
+        "PlayerUp": 1609,
         "ScoreAdr": 1408,
         "BytesInScore": 4,
         "ScoreSpacing": 32,

--- a/src/data_east/config/LastActHero_113.json
+++ b/src/data_east/config/LastActHero_113.json
@@ -16,7 +16,7 @@
     },
     "DisplayMessage": {
         "Type": 20,
-        "Address": 1458
+        "Address": 8001
     },
     "Adjustments": {
         "Type": 20,
@@ -38,7 +38,7 @@
     },
     "InPlay": {
         "Type": 24,
-        "Players": 342,
+        "Players": 431,
         "PlayerUp": 428,
         "ScoreAdr": 5846,
         "BytesInScore": 5,

--- a/src/data_east/config/LeathalWeap_208.json
+++ b/src/data_east/config/LeathalWeap_208.json
@@ -20,7 +20,7 @@
     },
     "Adjustments": {
         "Type": 20,
-        "CustomMessageOn": 7009,
+        "CustomMessageOn": 7755,
         "ChecksumStartAdr": 7678,
         "ChecksumEndAdr": 7769,
         "ChecksumResultAdr": 8128,

--- a/src/data_east/config/Simpsons_27.json
+++ b/src/data_east/config/Simpsons_27.json
@@ -21,8 +21,8 @@
     "Adjustments": {
         "Type": 20,
         "CustomMessageOn": 7742,
-        "ChecksumStartAdr": 7713,
-        "ChecksumEndAdr": 7754,
+        "ChecksumStartAdr": 7678,
+        "ChecksumEndAdr": 7748,
         "ChecksumResultAdr": 7902
     },
     "HighScores": {

--- a/src/data_east/config/Simpsons_27.json
+++ b/src/data_east/config/Simpsons_27.json
@@ -27,14 +27,14 @@
     },
     "HighScores": {
         "Type": 20,
-        "ScoreAdr": 7582,
-        "BytesInScore": 6,
+        "ScoreAdr": 7584,
+        "BytesInScore": 4,
         "ScoreSpacing": 4,
         "Multiplier": 1,
         "InitialAdr": 7628,
         "InitialSpacing": 3,
         "NumberOfScores": 6,
-        "ScoreAdrNV": 7707
+        "ScoreAdrNV": 7709
     },
     "InPlay": {
         "Type": 20,

--- a/src/data_east/config/StarTrek_201.json
+++ b/src/data_east/config/StarTrek_201.json
@@ -20,7 +20,7 @@
     },
     "Adjustments": {
         "Type": 20,
-        "CustomMessageOn": 7009,
+        "CustomMessageOn": 7742,
         "ChecksumStartAdr": 7680,
         "ChecksumEndAdr": 7747,
         "ChecksumResultAdr": 8128

--- a/src/data_east/config/TalesCrypt_500.json
+++ b/src/data_east/config/TalesCrypt_500.json
@@ -20,7 +20,7 @@
     },
     "Adjustments": {
         "Type": 20,
-        "CustomMessageOn": 7009,
+        "CustomMessageOn": 7757,
         "ChecksumStartAdr": 7678,
         "ChecksumEndAdr": 7807,
         "ChecksumResultAdr": 8157
@@ -38,7 +38,7 @@
     },
     "InPlay": {
         "Type": 24,
-        "Players": 434,
+        "Players": 437,
         "PlayerUp": 434,
         "ScoreAdr": 6006,
         "BytesInScore": 5,

--- a/src/data_east/config/Tommy_400.json
+++ b/src/data_east/config/Tommy_400.json
@@ -27,18 +27,18 @@
     },
     "HighScores": {
         "Type": 24,
-        "ScoreAdr": 5752,
+        "ScoreAdr": 5756,
         "BytesInScore": 5,
         "ScoreSpacing": 4,
         "Multiplier": 1,
         "InitialAdr": 5818,
         "InitialSpacing": 3,
         "NumberOfScores": 6,
-        "ScoreAdrNV": 5901
+        "ScoreAdrNV": 7711
     },
     "InPlay": {
         "Type": 24,
-        "Players": 383,
+        "Players": 437,
         "PlayerUp": 434,
         "ScoreAdr": 5846,
         "BytesInScore": 5,

--- a/src/data_east/config/TorpAlley_21.json
+++ b/src/data_east/config/TorpAlley_21.json
@@ -21,9 +21,9 @@
     "Adjustments": {
         "Type": 20,
         "CustomMessageOn": 8114,
-        "ChecksumStartAdr": 8074,
-        "ChecksumEndAdr": 8088,
-        "ChecksumResultAdr": 8150
+        "ChecksumStartAdr": 8060,
+        "ChecksumEndAdr": 8185,
+        "ChecksumResultAdr": 8190
     },
     "HighScores": {
         "Type": 20,
@@ -38,7 +38,7 @@
     "InPlay": {
         "Type": 20,
         "Players": 1610,
-        "PlayerUp": 1556,
+        "PlayerUp": 1609,
         "ScoreAdr": 1408,
         "BytesInScore": 4,
         "ScoreSpacing": 32,

--- a/src/data_east/config/Turtles_104.json
+++ b/src/data_east/config/Turtles_104.json
@@ -27,14 +27,14 @@
     },
     "HighScores": {
         "Type": 20,
-        "ScoreAdr": 7582,
-        "BytesInScore": 6,
+        "ScoreAdr": 7584,
+        "BytesInScore": 4,
         "ScoreSpacing": 4,
         "Multiplier": 1,
         "InitialAdr": 7628,
         "InitialSpacing": 3,
         "NumberOfScores": 6,
-        "ScoreAdrNV": 7707
+        "ScoreAdrNV": 7709
     },
     "InPlay": {
         "Type": 20,

--- a/src/data_east/systemConfig.py
+++ b/src/data_east/systemConfig.py
@@ -2,7 +2,7 @@ vectorSystem = "data_east"
 updatesURL = "http://software.warpedpinball.com/vector/data_east/latest.json"
 
 # Firmware version for the Data East build
-SystemVersion = "1.0.12"
+SystemVersion = "1.0.13"
 
 
 # System specific scheduled tasks


### PR DESCRIPTION
Fixing  configuration issues in Torpedo Alley
Found a few other configuration issues, all fixed here

## Related Issues
Discovered problem with some 4 digit scores being mis-coded as 6 digit.  Fixed config files.
Added guards to some data mapper code

## Motivation and Context
<!--- Explain why this change is required and what problem it solves -->

## Testing
<!--- Describe your testing steps, environments, and any relevant details -->

## Screenshots (if applicable)
<!--- Add screenshots if appropriate -->

## Types of Changes
- [ ] Bug fix (non-breaking change to resolve an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] Documentation update required

## Checklist
- [ ] My code follows the project’s style guidelines.
- [ ] I have updated documentation as needed.
- [ ] I have read the CONTRIBUTING.md document.
- [ ] I have added or updated tests.
- [ ] All new and existing tests pass.

## Additional Notes
<!--- Add any extra information here -->
