### PR TITLE
Fault LED driver update

### DIFF
--- a/src/common/SharedState.py
+++ b/src/common/SharedState.py
@@ -1,4 +1,4 @@
-VectorVersion = "1.12.1"
+VectorVersion = "1.12.2"
 
 
 # counts game start cycles

--- a/src/common/faults.py
+++ b/src/common/faults.py
@@ -9,7 +9,7 @@ import BoardLED as L
 import machine
 import rp2
 import SharedState as S
-from micropython import const
+from micropython import const, schedule
 from phew import is_connected_to_wifi
 
 # Hardware Faults
@@ -102,8 +102,16 @@ timer = machine.Timer()
 enableWS2812led = False
 sequence = [L.BLACK]
 index = 0
-update_sequence_continuous = 75  # about 1 minute at timer period of 790ms
+update_sequence_continuous = 152  # about 2 minutes at timer period of 790ms
 LED_Out = None
+_led_refresh_pending = False
+
+
+def _refresh_led_sequence(_):
+    """Rebuild the LED sequence. Deferred off the timer IRQ via micropython.schedule()."""
+    global _led_refresh_pending
+    _led_refresh_pending = False
+    update_led_sequence()
 
 
 def initialize_board_LED():
@@ -116,19 +124,22 @@ def initialize_board_LED():
     else:
 
         def _timerCallBack(_):
-            """
-            Timer callback to update LED color based on fault sequence
-            """
-            global index, sequence, update_sequence_continuous
+            """Advance the blink sequence only - keep the IRQ minimal; the
+            sequence rebuild is deferred to _refresh_led_sequence()."""
+            global index, _led_refresh_pending, update_sequence_continuous
 
-            # If the sequence has shortened or we reached the end, reset the index
-            index = index if index < len(sequence) else 0
-            L.ledColor(sequence[index])
+            seq = sequence
+            if index >= len(seq):
+                index = 0
+            L.ledColor(seq[index])
             index = index + 1
 
             if update_sequence_continuous > 0:
-                update_led_sequence()
                 update_sequence_continuous -= 1
+                # rebuild the sequence only every 3rd tick - keeps the deferred work light
+                if update_sequence_continuous % 3 == 0 and not _led_refresh_pending:
+                    _led_refresh_pending = True
+                    schedule(_refresh_led_sequence, 0)
 
         L.startUp()
         L.ledOff()
@@ -162,20 +173,6 @@ def get_fault_led_sequence(fault):
 def update_led_sequence():
     global sequence
 
-    led_sequences = [get_fault_led_sequence(fault) for fault in S.faults]
-
-    # Separate each fault code sequence with OFF states
-    code_sep = [L.BLACK, L.BLACK, L.BLACK]
-    combined_sequence = []
-    for seq in led_sequences:
-        combined_sequence.extend(seq)
-        combined_sequence.extend(code_sep)
-
-    if combined_sequence:
-        sequence = combined_sequence
-        return
-
-    # no faults - get and report normal status
     def in_ap_mode():
         """A lightly cursed way to determine if we are in AP mode without using global memory"""
         from json import loads
@@ -187,6 +184,24 @@ def update_led_sequence():
             return False
         return loads(route(0)[0])["in_ap_mode"]
 
+    led_sequences = [get_fault_led_sequence(fault) for fault in S.faults]
+
+    # Separate each fault code sequence with OFF states
+    code_sep = [L.BLACK, L.BLACK, L.BLACK]
+    combined_sequence = []
+    for seq in led_sequences:
+        combined_sequence.extend(seq)
+        combined_sequence.extend(code_sep)
+
+    if combined_sequence:
+        # if we're also in AP mode, tack the AP-mode blink on after the fault codes
+        if in_ap_mode():
+            combined_sequence.extend([L.PURPLE, L.PURPLE_DIM])
+            combined_sequence.extend(code_sep)
+        sequence = combined_sequence
+        return
+
+    # no faults - get and report normal status
     if in_ap_mode():
         combined_sequence = [L.PURPLE, L.PURPLE_DIM]  # AP mode
     elif is_connected_to_wifi():


### PR DESCRIPTION
## Description
Previously had some Wifi chip access code inside the initalize_board_LED():_ timerCallBack() which may have sometime created issues for access to the Wifi chip when the timer hit on a time slice where normal access was already happening.  Moved code out to a scheduled tasks and now only set a flag and scheduler in the timer callback.

These operations happen before our normal scheduler is up and running - so we provide fault LED and status LED feedback.

Also now allow AP mode blink to add on to another fault blink.  (example bad configuration causes AP mode: so show both codes for clarity)

## Related Issues
<!--- Link to any open issues this PR addresses, e.g., Closes #123 or Resolves #456 -->

## Motivation and Context
<!--- Explain why this change is required and what problem it solves -->

## Testing
Checked on Classic and WPC: AP mode, ap mode with bad confg, bad wifi password and all good states

## Screenshots (if applicable)
<!--- Add screenshots if appropriate -->

## Types of Changes
- [ ] Bug fix (non-breaking change to resolve an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] Documentation update required

## Checklist
- [ ] My code follows the project’s style guidelines.
- [ ] I have updated documentation as needed.
- [ ] I have read the CONTRIBUTING.md document.
- [ ] I have added or updated tests.
- [ ] All new and existing tests pass.

## Additional Notes
<!--- Add any extra information here -->
